### PR TITLE
BUG-908: Rajapinnan ilmoittautumiskaudet

### DIFF
--- a/core/src/main/scala/fi/vm/sade/hakurekisteri/integration/tarjonta/TarjontaActor.scala
+++ b/core/src/main/scala/fi/vm/sade/hakurekisteri/integration/tarjonta/TarjontaActor.scala
@@ -42,7 +42,10 @@ case class TarjontaKoodi(arvo: Option[String])
 case class Koulutus(oid: String,
                     komoOid: String,
                     tunniste: Option[String],
-                    kandidaatinKoulutuskoodi: Option[TarjontaKoodi])
+                    kandidaatinKoulutuskoodi: Option[TarjontaKoodi],
+                    koulutuksenAlkamiskausi: Option[TarjontaKoodi],
+                    koulutuksenAlkamisvuosi: Option[Int],
+                    koulutuksenAlkamisPvms: Option[Set[Long]])
 
 case class HakukohdeOid(oid: String)
 
@@ -52,7 +55,10 @@ case class Hakukohde(oid: String,
 
 case class Hakukohteenkoulutus(komoOid: String,
                                tkKoulutuskoodi: String,
-                               kkKoulutusId: Option[String])
+                               kkKoulutusId: Option[String],
+                               koulutuksenAlkamiskausi: Option[TarjontaKoodi],
+                               koulutuksenAlkamisvuosi: Option[Int],
+                               koulutuksenAlkamisPvms: Option[Set[Long]])
 
 case class HakukohteenKoulutukset(hakukohdeOid: String,
                                   ulkoinenTunniste: Option[String],
@@ -105,8 +111,8 @@ class TarjontaActor(restClient: VirkailijaRestClient, config: Config) extends Ac
           case None => throw KomoNotFoundException(s"komo not found with oid ${k.komoOid}")
           case Some(komo) =>
             val kkKoulutusId = k.tunniste.flatMap(_.blankOption)
-            val koulutukset = Seq(Hakukohteenkoulutus(komo.oid, komo.koulutuskoodi.arvo, kkKoulutusId))
-            k.kandidaatinKoulutuskoodi.flatMap(_.arvo.map(a => koulutukset :+ Hakukohteenkoulutus(komo.oid, a, kkKoulutusId))).getOrElse(koulutukset)
+            val koulutukset = Seq(Hakukohteenkoulutus(komo.oid, komo.koulutuskoodi.arvo, kkKoulutusId, k.koulutuksenAlkamiskausi, k.koulutuksenAlkamisvuosi, k.koulutuksenAlkamisPvms))
+            k.kandidaatinKoulutuskoodi.flatMap(_.arvo.map(a => koulutukset :+ Hakukohteenkoulutus(komo.oid, a, kkKoulutusId, k.koulutuksenAlkamiskausi, k.koulutuksenAlkamisvuosi, k.koulutuksenAlkamisPvms))).getOrElse(koulutukset)
         }
     }
   }

--- a/web/src/main/scala/fi/vm/sade/hakurekisteri/web/kkhakija/KkHakijaResource.scala
+++ b/web/src/main/scala/fi/vm/sade/hakurekisteri/web/kkhakija/KkHakijaResource.scala
@@ -572,8 +572,8 @@ object KkHakijaUtil {
     val date: DateTime = new DateTime(d)
     val year: Int = date.getYear
     val kausi: String = date.getMonthOfYear match {
-      case m if m > 0 && m < 7    => "K"
-      case m if m >= 7 && m <= 12 => "S"
+      case m if m >= 1 && m <= 7  => "K"   // 1.1 - 31.7    Spring season
+      case m if m >= 8 && m <= 12 => "S"   // 1.8 - 31.12   Autumn season
       case _ => throw new scala.IllegalArgumentException("Invalid date provided.")
     }
     (kausi, year)


### PR DESCRIPTION
Käytetään Tarjonnan koulutus tietoja Haun tietojen sijaan
määriteltäessä ilmoittautumistiedot. Tämä ottaa kantaa siihen
tilanteeseen jossa haku on esimerkiksi syksyllä mutta, koulutus
alkaakin vasta syksyllä seuraavana vuonna. Tällöin aiemmin
ilmoittautumisiksi tuli kevät ja syksy eikä syksy ja kevät tulevia
vuosia.

Kattokee tarkasti etten hölömöillyt!!

https://jira.oph.ware.fi/jira/browse/BUG-908