### PR TITLE
Fix for updating suoritus data of most recent applications

### DIFF
--- a/src/main/scala/fi/vm/sade/hakurekisteri/integration/hakemus/IlmoitetutArvosanatTrigger.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/integration/hakemus/IlmoitetutArvosanatTrigger.scala
@@ -68,7 +68,7 @@ object IlmoitetutArvosanatTrigger {
   def apply(suoritusRekisteri: ActorRef, arvosanaRekisteri: ActorRef)(implicit ec: ExecutionContext): Trigger = {
     Trigger {
       (hakemus, personOidsWithAliases: PersonOidsWithAliases) => {
-        muodostaSuorituksetJaArvosanat(hakemus, suoritusRekisteri, arvosanaRekisteri, personOidsWithAliases)
+        muodostaSuorituksetJaArvosanat(hakemus, suoritusRekisteri, arvosanaRekisteri, personOidsWithAliases.intersect(hakemus.personOid.toSet))
       }
     }
   }

--- a/src/main/scala/fi/vm/sade/hakurekisteri/integration/henkilo/oppijaNumeroRekisteri.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/integration/henkilo/oppijaNumeroRekisteri.scala
@@ -97,6 +97,11 @@ case class PersonOidsWithAliases(henkiloOids: Set[String], aliasesByPersonOids: 
     PersonOidsWithAliases(henkiloOids -- henkiloOidsToRemove, aliasesByPersonOids -- henkiloOidsToRemove)
   }
 
+  def intersect(henkiloOidsToInclude: Set[String]): PersonOidsWithAliases = {
+    PersonOidsWithAliases(henkiloOids.intersect(henkiloOidsToInclude),
+      aliasesByPersonOids.filter { case (key, value) => henkiloOidsToInclude.contains(key) })
+  }
+
   def isEmpty: Boolean = aliasesByPersonOids.isEmpty
 
   private def isSinglePersonWithoutAliases: Boolean = henkiloOids.size == 1 && aliasesByPersonOids(henkiloOids.head).size == 1

--- a/src/main/scala/fi/vm/sade/hakurekisteri/storage/ResourceActor.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/storage/ResourceActor.scala
@@ -47,7 +47,12 @@ abstract class ResourceActor[T <: Resource[I, T] : Manifest, I : Manifest] exten
       sender ! operationOrFailure(() => getAll(ids.asInstanceOf[Seq[I]]))
 
     case InsertResource(resource: T, personOidsWithAliases: PersonOidsWithAliases) =>
-      sender ! operationOrFailure(() => insert(resource, personOidsWithAliases))
+      if (personOidsWithAliases.henkiloOids.size > 1) {
+        sender ! Failure(new IllegalArgumentException(s"Got ${personOidsWithAliases.henkiloOids.size} person aliases " +
+          s"for inserting a single resource $resource . This would make the deduplication query unneccessarily heavy."))
+      } else {
+        sender ! operationOrFailure(() => insert(resource, personOidsWithAliases))
+      }
 
     case LogMessage(message, level) =>
       log.log(level, message)

--- a/src/main/scala/fi/vm/sade/hakurekisteri/suoritus/SuoritusQuery.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/suoritus/SuoritusQuery.scala
@@ -27,7 +27,9 @@ object SuoritusQuery {
   }
 }
 
-case class SuoritusQueryWithPersonAliases(wrappedQuery: SuoritusQuery, personOidsWithAliases: PersonOidsWithAliases) extends Query[Suoritus]
+case class SuoritusQueryWithPersonAliases(wrappedQuery: SuoritusQuery, fullPersonOidsWithAliases: PersonOidsWithAliases) extends Query[Suoritus] {
+  val personOidsWithAliases: PersonOidsWithAliases = fullPersonOidsWithAliases.intersect(wrappedQuery.henkilo.toSet)
+}
 case class SuoritusHenkilotQuery(henkilot: PersonOidsWithAliases) extends Query[Suoritus]
 case class SuoritysTyyppiQuery(henkilo: String, komo: String) extends Query[Suoritus]
 case class AllForMatchinHenkiloSuoritusQuery(vuosi: Option[String] = None, myontaja: Option[String] = None) extends Query[Suoritus]

--- a/src/test/scala/fi/vm/sade/hakurekisteri/integration/ArvosanaResourceIntegrationSpec.scala
+++ b/src/test/scala/fi/vm/sade/hakurekisteri/integration/ArvosanaResourceIntegrationSpec.scala
@@ -39,6 +39,11 @@ class ArvosanaResourceIntegrationSpec extends FlatSpec with CleanSharedTestJetty
   def responseIds(body: String): Seq[String] = parse(body).extract[JArray].arr
     .map(_.extract[JObject].values("id").asInstanceOf[String])
 
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    ItPostgres.reset()
+  }
+
   override def afterAll(): Unit = {
     super.afterAll()
     database.close()

--- a/src/test/scala/fi/vm/sade/hakurekisteri/integration/henkilo/PersonOidsWithAliasesSpec.scala
+++ b/src/test/scala/fi/vm/sade/hakurekisteri/integration/henkilo/PersonOidsWithAliasesSpec.scala
@@ -1,0 +1,33 @@
+package fi.vm.sade.hakurekisteri.integration.henkilo
+
+import fi.vm.sade.hakurekisteri.SpecsLikeMockito
+import fi.vm.sade.hakurekisteri.test.tools.FutureWaiting
+import org.scalatest.concurrent.AsyncAssertions
+import org.scalatest.{FlatSpec, Matchers}
+
+class PersonOidsWithAliasesSpec extends FlatSpec with Matchers with FutureWaiting with SpecsLikeMockito with AsyncAssertions {
+
+  private val henkiloOids = Set("1.1.1.1", "2.2.2.2", "3.3.3.3", "4.4.4.4")
+  private val aliases = Map(
+    "1.1.1.1" -> Set("1.1.1.1", "9.9.9.9"),
+    "2.2.2.2" -> Set("2.2.2.2"),
+    "3.3.3.3" -> Set("3.3.3.3"),
+    "4.4.4.4" -> Set("4.4.4.4"))
+  private val withFourOids = PersonOidsWithAliases(henkiloOids, aliases)
+
+  behavior of "PersonOidsWithAliases"
+
+  it should "combine initial oids with map set" in {
+    withFourOids.henkiloOids should have size 4
+    withFourOids.aliasesByPersonOids should have size 4
+    withFourOids.henkiloOidsWithLinkedOids should have size 5
+  }
+
+  it should "be able to filter out other than given person oids" in {
+    val withTwoOids = withFourOids.intersect(Set("1.1.1.1", "3.3.3.3"))
+    withTwoOids.henkiloOids should have size 2
+    withTwoOids.aliasesByPersonOids should have size 2
+    withTwoOids.henkiloOidsWithLinkedOids should have size 3
+    withTwoOids.aliasesByPersonOids("1.1.1.1") should equal(Set("1.1.1.1", "9.9.9.9"))
+  }
+}


### PR DESCRIPTION
Bugi on semmoinen että kun Suresta ladataan käynnistyksen yhteydessä viimeisen 2 päivän aikana muokatut hakemukset, ja niiden hakijoille sitten ko. hakijan suoritukset yksi kerrallaan, niin siinä välitetään turhaan koko hakemussetin hakijoiden henkilöoidit mukaan, ja tämä tekee hausta turhaan raskan.

QA:n muokattujen hakemusten määrillä tämä ei näkynyt niin selvästi, että olisimme huomanneet asian, mutta tuotannossa se jumitti koko Suren.

Korjauksena varmistellaan eri tavoin, että JDBC-kerrokselle asti välitettävässä `PersonOidsWithAliases` -oliossa ei olisi kuin tarvittavien henkilöioidien linkitystieto mukana.

Samalla löytyi samanhenkinen palasteluun liittyvä TODO OppijaFetcheristä, joten korjasin senkin.