### PR TITLE
Refactor getRinnasteinenKoodiArvoQuery in KoodistoActor

### DIFF
--- a/src/main/resources/suoritusrekisteri-oph.properties
+++ b/src/main/resources/suoritusrekisteri-oph.properties
@@ -12,6 +12,7 @@ authentication-service.s2s.tiedonsiirrot=/authentication-service/resources/s2s/t
 authentication-service.henkiloSearchQ=/authentication-service/resources/henkilo?q=$1&index=0&count=$2&no=true&s=true
 koodisto-service.koodiByUri=/koodisto-service/rest/json/$1/koodi/$2
 koodisto-service.koodisByKoodisto=/koodisto-service/rest/json/$1/koodi
+koodisto-service.koodisByKoodistoAndArvo=/koodisto-service/rest/json/$1/koodi/arvo/$2
 koodisto-service.relaatio=/koodisto-service/rest/json/relaatio/$1/$2
 organisaatio-service.ryhmat=/organisaatio-service/rest/organisaatio/v2/ryhmat
 organisaatio-service.organisaatio=/organisaatio-service/rest/organisaatio/$1

--- a/src/main/scala/fi/vm/sade/hakurekisteri/hakija/HakijaActor.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/hakija/HakijaActor.scala
@@ -246,7 +246,7 @@ class HakijaActor(hakupalvelu: Hakupalvelu, organisaatioActor: ActorRef, koodist
   def getMaakoodi(koodiArvo: String): Future[String] = koodiArvo.toLowerCase match {
     case "fin" => Future.successful("246")
     case arvo =>
-      val maaFuture = (koodistoActor ? GetRinnasteinenKoodiArvoQuery("maatjavaltiot1_" + arvo, "maatjavaltiot2")).mapTo[String]
+      val maaFuture = (koodistoActor ? GetRinnasteinenKoodiArvoQuery("maatjavaltiot1", arvo, "maatjavaltiot2")).mapTo[String]
       maaFuture.onFailure {
         case t: Throwable => log.error(t, s"failed to fetch country $koodiArvo")
       }

--- a/src/main/scala/fi/vm/sade/hakurekisteri/web/kkhakija/KkHakijaService.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/web/kkhakija/KkHakijaService.scala
@@ -502,7 +502,7 @@ object KkHakijaUtil {
     case "" => Future.successful("999")
 
     case arvo =>
-      (koodisto ? GetRinnasteinenKoodiArvoQuery("maatjavaltiot1_" + arvo, "maatjavaltiot2")).mapTo[String]
+      (koodisto ? GetRinnasteinenKoodiArvoQuery("maatjavaltiot1", arvo, "maatjavaltiot2")).mapTo[String]
   }
 
   def getToimipaikka(maa: String, postinumero: Option[String], kaupunkiUlkomaa: Option[String], koodisto: ActorRef)

--- a/src/test/scala/fi/vm/sade/hakurekisteri/acceptance/tools/HakeneetSupport.scala
+++ b/src/test/scala/fi/vm/sade/hakurekisteri/acceptance/tools/HakeneetSupport.scala
@@ -581,8 +581,8 @@ trait HakeneetSupport extends Suite with HttpComponentsClient with Hakurekisteri
 
   class MockedKoodistoActor extends Actor {
     override def receive: Actor.Receive = {
-      case GetRinnasteinenKoodiArvoQuery("maatjavaltiot1_fin", _) => sender ! "246"
-      case GetRinnasteinenKoodiArvoQuery("maatjavaltiot1_nan", _) => sender ! "999"
+      case GetRinnasteinenKoodiArvoQuery("maatjavaltiot1", "fin", _) => sender ! "246"
+      case GetRinnasteinenKoodiArvoQuery("maatjavaltiot1", "nan", _) => sender ! "999"
       case q: GetKoodi =>
         sender ! Some(Koodi(q.koodiUri.split("_").last.split("#").head.toUpperCase, q.koodiUri, Koodisto(q.koodistoUri), Seq(KoodiMetadata(q.koodiUri.capitalize, "FI"))))
     }

--- a/src/test/scala/fi/vm/sade/hakurekisteri/koodisto/KoodistoActorSpec.scala
+++ b/src/test/scala/fi/vm/sade/hakurekisteri/koodisto/KoodistoActorSpec.scala
@@ -1,0 +1,49 @@
+package fi.vm.sade.hakurekisteri.koodisto
+
+import akka.actor.ActorSystem
+import akka.testkit.TestActorRef
+import fi.vm.sade.hakurekisteri.MockConfig
+import fi.vm.sade.hakurekisteri.integration.VirkailijaRestClient
+import fi.vm.sade.hakurekisteri.integration.koodisto.{GetRinnasteinenKoodiArvoQuery, Koodi, Koodisto, KoodistoActor}
+import org.scalatest.Matchers
+import org.scalatra.test.scalatest.ScalatraFunSuite
+import org.mockito.Mockito._
+import org.scalatest.mock.MockitoSugar
+
+import scala.concurrent.{Await, Future}
+import scala.concurrent.duration._
+
+class KoodistoActorSpec extends ScalatraFunSuite with Matchers with MockitoSugar {
+  private val koodisto = "koodisto"
+  private val koodiArvo = "arvo"
+  private val koodiUri = "uri"
+  private val rinnasteinenKoodisto = "rinnasteinenKoodisto"
+  private val rinnasteinenArvo = "rinnasteinenArvo"
+  private val rinnasteinenUri = "rinnasteinenUri"
+  private val responseCode = 200
+  private val maxRetries = 1
+
+  implicit val system: ActorSystem = ActorSystem()
+
+  val mockRestClient = mock[VirkailijaRestClient]
+  val mockKoodi = Koodi(koodiArvo, koodiUri, Koodisto(koodisto), null)
+  val mockRinnasteinen = Koodi(rinnasteinenArvo, rinnasteinenUri, Koodisto(rinnasteinenKoodisto), null)
+  val koodistoActor = TestActorRef(new KoodistoActor(mockRestClient, new MockConfig())).underlyingActor
+
+  when(mockRestClient.readObject[Seq[Koodi]]("koodisto-service.koodisByKoodistoAndArvo", koodisto, koodiArvo)(responseCode, maxRetries)).thenReturn(
+    Future.successful(Seq(mockKoodi))
+  )
+
+  when(mockRestClient.readObject[Seq[Koodi]]("koodisto-service.relaatio", "rinnasteinen", koodiUri)(responseCode, maxRetries)).thenReturn(
+    Future.successful(Seq(mockRinnasteinen))
+  )
+
+  test("should fetch rinnasteinen koodiarvo from koodisto for given koodiarvo") {
+    Await.result(koodistoActor.getRinnasteinenKoodiArvo(GetRinnasteinenKoodiArvoQuery(koodisto, koodiArvo, rinnasteinenKoodisto)), Duration.Inf) should be(mockRinnasteinen.koodiArvo)
+  }
+
+  override def stop(): Unit = {
+    Await.result(system.terminate(), 15.seconds)
+    super.stop()
+  }
+}


### PR DESCRIPTION
* Refactor rinnasteinen koodiarvo querying from koodisto to
  1. query the koodiuri for the koodiarvo from koodisto
  2. use that koodiuri to query the rinnasteinen koodiarvo from koodisto
  in order to avoid error-prone koodiuri construction in KoodistoActor.