### PR TITLE
OY-131 :  Read client IP address also from X-Real-IP header

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,8 +24,13 @@
         </dependency>
         <dependency>
             <groupId>fi.vm.sade.java-utils</groupId>
+            <artifactId>java-http</artifactId>
+            <version>0.1.1-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>fi.vm.sade.java-utils</groupId>
             <artifactId>httpclient</artifactId>
-            <version>0.2.0-SNAPSHOT</version>
+            <version>0.2.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.spire-math</groupId>
@@ -529,7 +534,7 @@
         <dependency>
             <groupId>fi.vm.sade.java-utils</groupId>
             <artifactId>java-cas</artifactId>
-            <version>0.1.0-SNAPSHOT</version>
+            <version>0.3.1-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>
@@ -590,7 +595,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.4</version>
+            <version>2.5</version>
         </dependency>
         <dependency>
             <groupId>org.jasig.cas.client</groupId>
@@ -753,12 +758,12 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.21</version>
+            <version>1.7.25</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <version>1.7.21</version>
+            <version>1.7.25</version>
         </dependency>
         <dependency>
             <groupId>org.clapper</groupId>
@@ -958,6 +963,10 @@
                 <exclusion>
                     <groupId>org.apache.commons</groupId>
                     <artifactId>commons-lang3</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-io</groupId>
+                    <artifactId>commons-io</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>net.java.dev.jna</groupId>
@@ -1332,6 +1341,10 @@
                 <exclusion>
                     <groupId>org.scala-lang.modules</groupId>
                     <artifactId>scala-xml_2.11</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/src/main/scala/fi/vm/sade/hakurekisteri/tools/ItPostgres.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/tools/ItPostgres.scala
@@ -40,7 +40,7 @@ object ItPostgres extends Logging {
     if (!pidFile.canRead) {
       None
     } else {
-      Some(FileUtils.readFileToString(pidFile).split("\n")(0).toInt)
+      Some(FileUtils.readFileToString(pidFile, "UTF-8").split("\n")(0).toInt)
     }
   }
 

--- a/src/main/scala/fi/vm/sade/hakurekisteri/web/jonotus/Siirtotiedostojono.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/web/jonotus/Siirtotiedostojono.scala
@@ -1,6 +1,7 @@
 package fi.vm.sade.hakurekisteri.web.jonotus
 
 import java.io.ByteArrayOutputStream
+import java.nio.charset.Charset
 import java.util.UUID
 import java.util.concurrent._
 
@@ -76,6 +77,8 @@ class Siirtotiedostojono(hakijaActor: ActorRef, kkHakija: KkHakijaService)(impli
         }
       })
 
+  private val charset: Charset = Charset.forName("UTF-8")
+
   def queryToAsiakirja(format: ApiFormat, query: HakijaQuery): Array[Byte] = {
     Await.result(hakijaActor ? query, defaultTimeout.duration) match {
       case hakijat: XMLHakijat =>
@@ -92,7 +95,7 @@ class Siirtotiedostojono(hakijaActor: ActorRef, kkHakija: KkHakijaService)(impli
               val printer = new scala.xml.PrettyPrinter(120, 2)
               val formattedXml = printer.format(hakijat.toXml)
               val bytes = new ByteArrayOutputStream()
-              IOUtils.write(formattedXml, bytes)
+              IOUtils.write(formattedXml, bytes, charset)
               bytes.toByteArray
           }
 
@@ -104,7 +107,7 @@ class Siirtotiedostojono(hakijaActor: ActorRef, kkHakija: KkHakijaService)(impli
           val bytes = new ByteArrayOutputStream()
           format match {
             case ApiFormat.Json =>
-              IOUtils.write(write(hakijat), bytes)
+              IOUtils.write(write(hakijat), bytes, charset)
               bytes.toByteArray
             case ApiFormat.Excel =>
               if(query.version == 2) {
@@ -130,7 +133,7 @@ class Siirtotiedostojono(hakijaActor: ActorRef, kkHakija: KkHakijaService)(impli
       val bytes = new ByteArrayOutputStream()
       format match {
         case ApiFormat.Json =>
-          IOUtils.write(write(hakijat), bytes)
+          IOUtils.write(write(hakijat), bytes, charset)
           bytes.toByteArray
         case ApiFormat.Excel =>
           if(query.version == 1) {

--- a/src/main/scala/fi/vm/sade/hakurekisteri/web/rest/support/SecuritySupport.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/web/rest/support/SecuritySupport.scala
@@ -5,6 +5,7 @@ import javax.servlet.http.HttpServletRequest
 
 import fi.vm.sade.hakurekisteri.Config
 import fi.vm.sade.hakurekisteri.rest.support.{AuditSessionRequest, OPHUser, User}
+import fi.vm.sade.javautils.http.HttpServletRequestUtils
 import org.apache.commons.lang3.builder.ToStringBuilder
 import org.springframework.security.core.{Authentication, GrantedAuthority}
 
@@ -30,7 +31,7 @@ class SpringSecurity extends Security {
   import scala.collection.JavaConverters._
 
   private def userAgent(r: HttpServletRequest): String = Option(r.getHeader("User-Agent")).getOrElse("Unknown user agent")
-  private def inetAddress(r: HttpServletRequest): String = Option(r.getHeader("X-Forwarded-For")).getOrElse(r.getRemoteAddr)
+  private def inetAddress(r: HttpServletRequest): String = HttpServletRequestUtils.getRemoteAddress(r)
 
   override def currentUser(implicit request: HttpServletRequest): Option[User] = userPrincipal.map {
     case a: Authentication => OPHUser(username(a), authorities(a).toSet,userAgent(request),inetAddress(request))


### PR DESCRIPTION
Tämä korjaa Suren tiedonsiirron (esim https://virkailija.untuva.aws.opintopolku.fi/suoritusrekisteri/#/tiedonsiirto/kkhakeneet ) käyttämän valinta-tulos-service-pyynnön. Se meni pilviympäristöissä rikki, kun `X-Forwarded-For` -headerissa oli useamman IP-osoitteen lista. Eli tämä on vastaava korjaus kun on jo tehty valinta-tulos-serviceen ja valintalaskentakoostepalveluun.