### PR TITLE
BUG-1645 : Suoritusrekisteri tekee valtavasti kyselyjä backendeihin

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -41,3 +41,18 @@ akka {
     }
   }
 }
+
+rediscala {
+  rediscala-client-worker-dispatcher {
+    type = "Dispatcher"
+    executor = "thread-pool-executor"
+    thread-pool-executor {
+      core-pool-size-min = 1
+      core-pool-size-factor = 3.0
+      core-pool-size-max = 10
+      max-pool-size-min = 1
+      max-pool-size-factor  = 3.0
+      max-pool-size-max = 10
+    }
+  }
+}

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -17,6 +17,14 @@ akka {
         max-pool-size-max = 64
       }
     }
+    // Note: loglevel needs to be set to debug to activate this debugging
+//    debug {
+//      receive = on
+//      autoreceive = on
+//      lifecycle = on
+//      unhandled = on
+//      fsm = on
+//    }
   }
   hakurekisteri {
     audit-dispatcher {

--- a/src/main/resources/oph-configuration/suoritusrekisteri.properties.template
+++ b/src/main/resources/oph-configuration/suoritusrekisteri.properties.template
@@ -83,6 +83,7 @@ suoritusrekisteri.cache.redis.port={{redis_suoritusrekisteri_port}}
 suoritusrekisteri.cache.redis.numberOfWaitersToLog={{redis_suoritusrekisteri_number_of_waiters_to_log | default('99')}}
 suoritusrekisteri.cache.redis.cacheItemLockMaxDurationSeconds={{redis_suoritusrekisteri_cache_item_lock_max_duraction_seconds | default('60')}}
 suoritusrekisteri.cache.redis.cacheHandlingThreadPoolSize={{redis_suoritusrekisteri_single_cache_threadpool_size | default('3')}}
+suoritusrekisteri.cache.redis.slowRedisRequestThresholdMillis={{redis_suoritusrekisteri_slow_request_threshold_millis | default('100')}}
 suoritusrekisteri.cache.hours.ensikertalainen=6
 suoritusrekisteri.cache.hours.koodisto=12
 suoritusrekisteri.cache.hours.organisaatio=12

--- a/src/main/resources/oph-configuration/suoritusrekisteri.properties.template
+++ b/src/main/resources/oph-configuration/suoritusrekisteri.properties.template
@@ -81,6 +81,7 @@ suoritusrekisteri.cache.redis.enabled={{redis_suoritusrekisteri_enabled}}
 suoritusrekisteri.cache.redis.host={{redis_suoritusrekisteri_host}}
 suoritusrekisteri.cache.redis.port={{redis_suoritusrekisteri_port}}
 suoritusrekisteri.cache.redis.numberOfWaitersToLog={{redis_suoritusrekisteri_number_of_waiters_to_log | default('99')}}
+suoritusrekisteri.cache.redis.cacheItemLockMaxDurationSeconds={{redis_suoritusrekisteri_cache_item_lock_max_duraction_seconds | default('60')}}
 suoritusrekisteri.cache.hours.ensikertalainen=6
 suoritusrekisteri.cache.hours.koodisto=12
 suoritusrekisteri.cache.hours.organisaatio=12

--- a/src/main/resources/oph-configuration/suoritusrekisteri.properties.template
+++ b/src/main/resources/oph-configuration/suoritusrekisteri.properties.template
@@ -81,7 +81,6 @@ suoritusrekisteri.cache.redis.enabled={{redis_suoritusrekisteri_enabled}}
 suoritusrekisteri.cache.redis.host={{redis_suoritusrekisteri_host}}
 suoritusrekisteri.cache.redis.port={{redis_suoritusrekisteri_port}}
 suoritusrekisteri.cache.redis.numberOfWaitersToLog={{redis_suoritusrekisteri_number_of_waiters_to_log | default('99')}}
-suoritusrekisteri.cache.redis.cacheItemLockMaxDurationSeconds={{redis_suoritusrekisteri_cache_item_lock_max_duraction_seconds | default('60')}}
 suoritusrekisteri.cache.redis.cacheHandlingThreadPoolSize={{redis_suoritusrekisteri_single_cache_threadpool_size | default('3')}}
 suoritusrekisteri.cache.redis.slowRedisRequestThresholdMillis={{redis_suoritusrekisteri_slow_request_threshold_millis | default('100')}}
 suoritusrekisteri.cache.hours.ensikertalainen=6

--- a/src/main/resources/oph-configuration/suoritusrekisteri.properties.template
+++ b/src/main/resources/oph-configuration/suoritusrekisteri.properties.template
@@ -80,6 +80,7 @@ log4j.properties.file=${user.home.conf}/log4j.properties
 suoritusrekisteri.cache.redis.enabled={{redis_suoritusrekisteri_enabled}}
 suoritusrekisteri.cache.redis.host={{redis_suoritusrekisteri_host}}
 suoritusrekisteri.cache.redis.port={{redis_suoritusrekisteri_port}}
+suoritusrekisteri.cache.redis.numberOfWaitersToLog={{redis_suoritusrekisteri_number_of_waiters_to_log | default('99')}}
 suoritusrekisteri.cache.hours.ensikertalainen=6
 suoritusrekisteri.cache.hours.koodisto=12
 suoritusrekisteri.cache.hours.organisaatio=12

--- a/src/main/resources/oph-configuration/suoritusrekisteri.properties.template
+++ b/src/main/resources/oph-configuration/suoritusrekisteri.properties.template
@@ -82,6 +82,7 @@ suoritusrekisteri.cache.redis.host={{redis_suoritusrekisteri_host}}
 suoritusrekisteri.cache.redis.port={{redis_suoritusrekisteri_port}}
 suoritusrekisteri.cache.redis.numberOfWaitersToLog={{redis_suoritusrekisteri_number_of_waiters_to_log | default('99')}}
 suoritusrekisteri.cache.redis.cacheItemLockMaxDurationSeconds={{redis_suoritusrekisteri_cache_item_lock_max_duraction_seconds | default('60')}}
+suoritusrekisteri.cache.redis.cacheHandlingThreadPoolSize={{redis_suoritusrekisteri_single_cache_threadpool_size | default('3')}}
 suoritusrekisteri.cache.hours.ensikertalainen=6
 suoritusrekisteri.cache.hours.koodisto=12
 suoritusrekisteri.cache.hours.organisaatio=12

--- a/src/main/scala/fi/vm/sade/hakurekisteri/integration/cache/CacheFactory.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/integration/cache/CacheFactory.scala
@@ -192,7 +192,7 @@ object CacheFactory {
               if (failIfNobodyWaiting) {
                 throw new IllegalStateException(s"Nobody waiting for results of $key , got result $result")
               } else {
-                logger.warn(s"Nobody waiting for results of $key, got result $result")
+                logger.debug(s"Nobody waiting for results of $key, got result $result")
               }
           }
         } finally {

--- a/src/main/scala/fi/vm/sade/hakurekisteri/integration/cache/CacheFactory.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/integration/cache/CacheFactory.scala
@@ -85,7 +85,7 @@ object CacheFactory {
       def get(key: K): Future[T] = {
         val prefixKey = k(key)
         val startTime = System.currentTimeMillis
-        logger.debug(s"Getting value with key ${prefixKey} from Redis cache")
+        logger.trace(s"Getting value with key ${prefixKey} from Redis cache")
         r.get[T](prefixKey).collect {
           case Some(x) =>
             val duration = System.currentTimeMillis - startTime

--- a/src/main/scala/fi/vm/sade/hakurekisteri/integration/cache/CacheFactory.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/integration/cache/CacheFactory.scala
@@ -63,7 +63,6 @@ object CacheFactory {
                            limitOfWaitingClientsToLog: Int) extends MonadCache[Future, K, T] {
 
       val logger = org.slf4j.LoggerFactory.getLogger(getClass)
-      //private val waitingPromisesHandlingSemaphore = new Semaphore(1)
       private val waitingPromisesHandlingLock = new ReentrantLock(true)
       private val waitingPromises: mutable.Map[K, java.util.List[Promise[Option[T]]]] = TrieMap[K, java.util.List[Promise[Option[T]]]]()
 

--- a/src/main/scala/fi/vm/sade/hakurekisteri/integration/cache/CacheFactory.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/integration/cache/CacheFactory.scala
@@ -109,13 +109,7 @@ object CacheFactory {
       private def k(key: K): String = k(key, cacheKeyPrefix)
 
       override def get(key: K, loader: K => Future[Option[T]]): Future[Option[T]] = {
-        r.exists(k(key)).flatMap { keyIsIncache =>
-          if (keyIsIncache) {
-            toOption(get(key))
-          } else {
-            updateConcurrencyHandler.initiateLoadingIfNotYetRunning(key, loader, this.+, k)
-          }
-        }
+        updateConcurrencyHandler.initiateLoadingIfNotYetRunning(key, loader, this.+, k)
       }
 
       override def toOption(value: Future[T]): Future[Option[T]] = value.map(Some(_))

--- a/src/main/scala/fi/vm/sade/hakurekisteri/integration/cache/CacheFactory.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/integration/cache/CacheFactory.scala
@@ -70,11 +70,10 @@ object CacheFactory {
 
       private val updateConcurrencyHandler = new RedisUpdateConcurrencyHandler[K,T](r, limitOfWaitingClientsToLog)
 
-      def +(key: K, f: Future[T]): Future[_] = f flatMap {
-        case t =>
-          val prefixKey = k(key)
-          logger.debug(s"Adding value with key ${prefixKey} to Redis cache")
-          r.set[T](prefixKey, t, pxMilliseconds = Some(expirationDurationMillis))
+      def +(key: K, value: T): Future[_] =  {
+        val prefixKey = k(key)
+        logger.debug(s"Adding value with key $prefixKey to Redis cache")
+        r.set[T](prefixKey, value, pxMilliseconds = Some(expirationDurationMillis))
       }
 
       def -(key: K): Unit = r.del(k(key))

--- a/src/main/scala/fi/vm/sade/hakurekisteri/integration/cache/CacheFactory.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/integration/cache/CacheFactory.scala
@@ -90,6 +90,9 @@ object CacheFactory {
 
       private def k(key: K): String = k(key, cacheKeyPrefix)
 
+      override def get(key: K, loader: K => Future[Option[T]]): Future[Option[T]] = ???
+
+      override def toOption(value: Future[T]): Future[Option[T]] = value.map(Some(_))
     }
 
     class ByteStringFormatterImpl[T] extends ByteStringFormatter[T] {

--- a/src/main/scala/fi/vm/sade/hakurekisteri/integration/cache/CacheFactory.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/integration/cache/CacheFactory.scala
@@ -51,7 +51,6 @@ object CacheFactory {
       expirationDurationMillis,
       cacheKeyPrefix,
       config.getProperty("suoritusrekisteri.cache.redis.numberOfWaitersToLog").toInt,
-      config.getProperty("suoritusrekisteri.cache.redis.cacheItemLockMaxDurationSeconds").toInt,
       config.getProperty("suoritusrekisteri.cache.redis.cacheHandlingThreadPoolSize").toInt,
       config.getProperty("suoritusrekisteri.cache.redis.slowRedisRequestThresholdMillis").toInt)
 
@@ -59,7 +58,6 @@ object CacheFactory {
                            val expirationDurationMillis: Long,
                            val cacheKeyPrefix: String,
                            limitOfWaitingClientsToLog: Int,
-                           cacheItemLockMaxDurationSeconds: Int,
                            cacheHandlingThreadPoolSize: Int,
                            slowRedisRequestThresholdMillis: Int
                           ) extends MonadCache[Future, K, T] {
@@ -70,7 +68,7 @@ object CacheFactory {
 
       implicit val byteStringFormatter = new ByteStringFormatterImpl[T]
 
-      private val updateConcurrencyHandler = new RedisUpdateConcurrencyHandler[K,T](r, limitOfWaitingClientsToLog, cacheItemLockMaxDurationSeconds)
+      private val updateConcurrencyHandler = new RedisUpdateConcurrencyHandler[K,T](r, limitOfWaitingClientsToLog)
 
       def +(key: K, f: Future[T]): Future[_] = f flatMap {
         case t =>

--- a/src/main/scala/fi/vm/sade/hakurekisteri/integration/cache/CacheFactory.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/integration/cache/CacheFactory.scala
@@ -1,8 +1,6 @@
 package fi.vm.sade.hakurekisteri.integration.cache
 
 import java.io._
-import java.util.Collections
-import java.util.concurrent.locks.ReentrantLock
 
 import akka.actor.ActorSystem
 import akka.util.ByteString
@@ -11,11 +9,8 @@ import fi.vm.sade.utils.Timer
 import org.apache.commons.io.IOUtils
 import redis.{ByteStringFormatter, RedisClient}
 
-import scala.collection.JavaConverters._
-import scala.collection.concurrent.TrieMap
-import scala.collection.mutable
 import scala.concurrent.duration._
-import scala.concurrent.{Await, Future, Promise}
+import scala.concurrent.{Await, Future}
 import scala.util.{Failure, Success, Try}
 
 trait CacheFactory {
@@ -65,12 +60,12 @@ object CacheFactory {
                            cacheItemLockMaxDurationSeconds: Int) extends MonadCache[Future, K, T] {
 
       val logger = org.slf4j.LoggerFactory.getLogger(getClass)
-      private val waitingPromisesHandlingLock = new ReentrantLock(true)
-      private val waitingPromises: mutable.Map[K, java.util.List[Promise[Option[T]]]] = TrieMap[K, java.util.List[Promise[Option[T]]]]()
 
       import scala.concurrent.ExecutionContext.Implicits.global
 
       implicit val byteStringFormatter = new ByteStringFormatterImpl[T]
+
+      private val updateConcurrencyHandler = new RedisUpdateConcurrencyHandler[K,T](r, limitOfWaitingClientsToLog, cacheItemLockMaxDurationSeconds)
 
       def +(key: K, f: Future[T]): Future[_] = f flatMap {
         case t =>
@@ -104,127 +99,16 @@ object CacheFactory {
       private def k(key: K): String = k(key, cacheKeyPrefix)
 
       override def get(key: K, loader: K => Future[Option[T]]): Future[Option[T]] = {
-        r.exists(k(key)).flatMap(keyIsIncache =>
+        r.exists(k(key)).flatMap { keyIsIncache =>
           if (keyIsIncache) {
             toOption(get(key))
           } else {
-            lockWaiterBookkeeping()
-            try {
-              initiateLoadingIfNotYetRunning(key, loader)
-            } finally {
-              releaseWaitingBookkeeping()
-            }
-          })
-      }
-
-      private def lockWaiterBookkeeping(): Unit = {
-        waitingPromisesHandlingLock.lock()
-        if (waitingPromisesHandlingLock.getHoldCount != 1) {
-          throw new IllegalStateException(s"After locking, waitingPromisesHandlingLock.getHoldCount == " +
-            s"${waitingPromisesHandlingLock.getHoldCount} – this should never happen.")
-        }
-      }
-
-      private def releaseWaitingBookkeeping(): Unit = {
-        if (waitingPromisesHandlingLock.getHoldCount != 1) {
-          throw new IllegalStateException(s"Before unlocking, waitingPromisesHandlingLock.getHoldCount == " +
-            s"${waitingPromisesHandlingLock.getHoldCount} – this should never happen.")
-        }
-        waitingPromisesHandlingLock.unlock()
-      }
-
-      private def initiateLoadingIfNotYetRunning(key: K, loader: K => Future[Option[T]]): Future[Option[T]] = {
-        val promisesOfThisKey = waitingPromises.getOrElseUpdate(key, { createSynchonizedList })
-        val newClientPromise: Promise[Option[T]] = Promise[Option[T]]
-        logger.debug("Adding new client promise:")
-        promisesOfThisKey.add(newClientPromise)
-        val numberWaiting = promisesOfThisKey.size
-        logger.debug(s"Waiting after adding: $numberWaiting")
-        if (numberWaiting > limitOfWaitingClientsToLog) {
-          logger.warn(s"Already $numberWaiting clients waiting for value of $key")
-        }
-
-        val prefixKey = k(key)
-        val lockKey = prefixKey + "-lock"
-        r.set(lockKey, "LOCKED", exSeconds = Some(cacheItemLockMaxDurationSeconds), NX = true).flatMap { lockObtained =>
-          if (lockObtained) {
-            logger.debug(s"Successfully acquired update lock of $lockKey")
-            r.get(prefixKey).onComplete {
-              case Success(found@Some(_)) =>
-                logger.debug(s"Value with $prefixKey had appeared in cache, no need to retrieve it.")
-                resolvePromisesWaitingForValueFromCache(key, Success(found))
-                removeCacheUpdateLock(lockKey)
-              case Success(None) =>
-                logger.debug(s"Starting retrieval of $prefixKey with loader function.")
-                retrieveNewvalueWithLoader(key, loader, lockKey)
-              case Failure(e) => newClientPromise.failure(e)
-            }
-          } else {
-            logger.debug(s"Could not acquire $lockKey, waiting patiently for my promise to be resolved. We're ${promisesOfThisKey.size} in total waiting")
+            updateConcurrencyHandler.initiateLoadingIfNotYetRunning(key, loader, this.+, k)
           }
-          newClientPromise.future
-        }.recoverWith { case e =>
-            logger.error(s"Error when obtaining lock $lockKey", e)
-            Future.failed(e)
-        }
-      }
-
-      private def retrieveNewvalueWithLoader(key: K, loader: K => Future[Option[T]], lockKey: String): Unit = {
-        val loadingFuture = loader(key)
-        loadingFuture.onComplete { result =>
-          if (result.isSuccess) {
-            result.get match {
-              case Some(foundItem) =>
-                this.+(key, Future.successful(foundItem)).onComplete { _ =>
-                  resolvePromisesWaitingForValueFromCache(key, result, failIfNobodyWaiting = false)
-                  removeCacheUpdateLock(lockKey)
-                }
-              case None =>
-                removeCacheUpdateLock(lockKey)
-            }
-          } else {
-            removeCacheUpdateLock(lockKey)
-          }
-          resolvePromisesWaitingForValueFromCache(key, result)
-        }
-      }
-
-      private def resolvePromisesWaitingForValueFromCache(key: K, result: Try[Option[T]], failIfNobodyWaiting: Boolean = true): Unit = {
-        lockWaiterBookkeeping()
-        try {
-          waitingPromises.remove(key) match {
-            case Some(promisesWaitingForResult) =>
-              logger.debug(s"Resolving promises for key $key: ${promisesWaitingForResult.size()}")
-              promisesWaitingForResult.asScala.foreach {
-                _.complete(result)
-              }
-            case None =>
-              if (failIfNobodyWaiting) {
-                throw new IllegalStateException(s"Nobody waiting for results of $key , got result $result")
-              } else {
-                logger.debug(s"Nobody waiting for results of $key, got result $result")
-              }
-          }
-        } finally {
-          releaseWaitingBookkeeping()
-        }
-      }
-
-      private def removeCacheUpdateLock(lockKey: String): Unit = {
-        val removalOfLock = r.del(lockKey)
-        removalOfLock.onSuccess { case _ =>
-          logger.debug(s"Successfully removed update lock $lockKey")
-        }
-        removalOfLock.onFailure { case e: Throwable =>
-          logger.error(s"Could not remove update lock $lockKey", e)
         }
       }
 
       override def toOption(value: Future[T]): Future[Option[T]] = value.map(Some(_))
-
-      private def createSynchonizedList: java.util.List[Promise[Option[T]]] = {
-        Collections.synchronizedList(new java.util.ArrayList[Promise[Option[T]]]())
-      }
     }
 
     class ByteStringFormatterImpl[T] extends ByteStringFormatter[T] {

--- a/src/main/scala/fi/vm/sade/hakurekisteri/integration/cache/RedisUpdateConcurrencyHandler.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/integration/cache/RedisUpdateConcurrencyHandler.scala
@@ -1,0 +1,147 @@
+package fi.vm.sade.hakurekisteri.integration.cache
+
+import java.util.Collections
+import java.util.concurrent.locks.ReentrantLock
+
+import redis.{ByteStringFormatter, RedisClient}
+
+import scala.collection.JavaConverters._
+import scala.collection.concurrent.TrieMap
+import scala.collection.mutable
+import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.util.{Failure, Success, Try}
+
+class RedisUpdateConcurrencyHandler[K, T](val r: RedisClient,
+                                          limitOfWaitingClientsToLog: Int,
+                                          cacheItemLockMaxDurationSeconds: Int)
+                                         (implicit val byteStringFormatter: ByteStringFormatter[T],
+                                           implicit val executionContext: ExecutionContext) {
+
+  private val logger = org.slf4j.LoggerFactory.getLogger(getClass)
+  private val waitingPromisesHandlingLock = new ReentrantLock(true)
+  private val waitingPromises: mutable.Map[K, java.util.List[Promise[Option[T]]]] = TrieMap[K, java.util.List[Promise[Option[T]]]]()
+
+  def initiateLoadingIfNotYetRunning(key: K,
+                                     loader: K => Future[Option[T]],
+                                     loadedValueStorer: (K, Future[T]) => Future[_],
+                                     keyPrefixer: K => String): Future[Option[T]] = {
+    lockWaiterBookkeeping()
+    try {
+      val newClientPromise = storePromiseForThisRequest(key)
+      val prefixKey = keyPrefixer(key)
+      val lockKey = prefixKey + "-lock"
+      r.set(lockKey, "LOCKED", exSeconds = Some(cacheItemLockMaxDurationSeconds), NX = true).flatMap { lockObtained =>
+        if (lockObtained) {
+          logger.debug(s"Successfully acquired update lock of $lockKey")
+          r.get(prefixKey).onComplete {
+            case Success(found@Some(_)) =>
+              logger.debug(s"Value with $prefixKey had appeared in cache, no need to retrieve it.")
+              resolvePromisesWaitingForValueFromCache(key, Success(found))
+              removeCacheUpdateLock(lockKey)
+            case Success(None) =>
+              logger.debug(s"Starting retrieval of $prefixKey with loader function.")
+              retrieveNewvalueWithLoader(key, loader, loadedValueStorer, lockKey)
+            case Failure(e) => newClientPromise.failure(e)
+          }
+        } else {
+          logger.debug(s"Could not acquire $lockKey, waiting patiently for my promise to be resolved. We're ${waitingPromises.get(key).map(_.size).getOrElse(0)} in total waiting")
+        }
+        newClientPromise.future
+      }.recoverWith { case e =>
+        logger.error(s"Error when obtaining lock $lockKey", e)
+        Future.failed(e)
+      }
+    } finally {
+      releaseWaitingBookkeeping()
+    }
+  }
+
+  private def storePromiseForThisRequest(key: K): Promise[Option[T]] = {
+    val promisesOfThisKey = waitingPromises.getOrElseUpdate(key, {
+      createSynchonizedList
+    })
+    val newClientPromise: Promise[Option[T]] = Promise[Option[T]]
+    logger.debug("Adding new client promise:")
+    promisesOfThisKey.add(newClientPromise)
+    val numberWaiting = promisesOfThisKey.size
+    logger.debug(s"Waiting after adding: $numberWaiting")
+    if (numberWaiting > limitOfWaitingClientsToLog) {
+      logger.warn(s"Already $numberWaiting clients waiting for value of $key")
+    }
+    newClientPromise
+  }
+
+  private def lockWaiterBookkeeping(): Unit = {
+    waitingPromisesHandlingLock.lock()
+    if (waitingPromisesHandlingLock.getHoldCount != 1) {
+      throw new IllegalStateException(s"After locking, waitingPromisesHandlingLock.getHoldCount == " +
+        s"${waitingPromisesHandlingLock.getHoldCount} – this should never happen.")
+    }
+  }
+
+  private def releaseWaitingBookkeeping(): Unit = {
+    if (waitingPromisesHandlingLock.getHoldCount != 1) {
+      throw new IllegalStateException(s"Before unlocking, waitingPromisesHandlingLock.getHoldCount == " +
+        s"${waitingPromisesHandlingLock.getHoldCount} – this should never happen.")
+    }
+    waitingPromisesHandlingLock.unlock()
+  }
+
+  private def retrieveNewvalueWithLoader(key: K,
+                                         loader: K => Future[Option[T]],
+                                         loadedValueStorer: (K, Future[T]) => Future[_],
+                                         lockKey: String): Unit = {
+    val loadingFuture = loader(key)
+    loadingFuture.onComplete { result =>
+      if (result.isSuccess) {
+        result.get match {
+          case Some(foundItem) =>
+            loadedValueStorer(key, Future.successful(foundItem)).onComplete { _ =>
+              resolvePromisesWaitingForValueFromCache(key, result, failIfNobodyWaiting = false)
+              removeCacheUpdateLock(lockKey)
+            }
+          case None =>
+            removeCacheUpdateLock(lockKey)
+        }
+      } else {
+        removeCacheUpdateLock(lockKey)
+      }
+      resolvePromisesWaitingForValueFromCache(key, result)
+    }
+  }
+
+  private def resolvePromisesWaitingForValueFromCache(key: K, result: Try[Option[T]], failIfNobodyWaiting: Boolean = true): Unit = {
+    lockWaiterBookkeeping()
+    try {
+      waitingPromises.remove(key) match {
+        case Some(promisesWaitingForResult) =>
+          logger.debug(s"Resolving promises for key $key: ${promisesWaitingForResult.size()}")
+          promisesWaitingForResult.asScala.foreach {
+            _.complete(result)
+          }
+        case None =>
+          if (failIfNobodyWaiting) {
+            throw new IllegalStateException(s"Nobody waiting for results of $key , got result $result")
+          } else {
+            logger.debug(s"Nobody waiting for results of $key, got result $result")
+          }
+      }
+    } finally {
+      releaseWaitingBookkeeping()
+    }
+  }
+
+  private def removeCacheUpdateLock(lockKey: String): Unit = {
+    val removalOfLock = r.del(lockKey)
+    removalOfLock.onSuccess { case _ =>
+      logger.debug(s"Successfully removed update lock $lockKey")
+    }
+    removalOfLock.onFailure { case e: Throwable =>
+      logger.error(s"Could not remove update lock $lockKey", e)
+    }
+  }
+
+  private def createSynchonizedList: java.util.List[Promise[Option[T]]] = {
+    Collections.synchronizedList(new java.util.ArrayList[Promise[Option[T]]]())
+  }
+}

--- a/src/main/scala/fi/vm/sade/hakurekisteri/integration/cache/RedisUpdateConcurrencyHandler.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/integration/cache/RedisUpdateConcurrencyHandler.scala
@@ -71,7 +71,7 @@ class RedisUpdateConcurrencyHandler[K, T](val r: RedisClient,
     if (numberWaiting > limitOfWaitingClientsToLog) {
       logger.warn(s"Already $numberWaiting clients waiting for value of $key")
     }
-    (newClientPromise, !otherPromises.isEmpty)
+    (newClientPromise, otherPromises.nonEmpty)
   }
 
   private def retrieveNewvalueWithLoader(key: K,

--- a/src/main/scala/fi/vm/sade/hakurekisteri/integration/cache/RedisUpdateConcurrencyHandler.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/integration/cache/RedisUpdateConcurrencyHandler.scala
@@ -5,7 +5,6 @@ import java.util.function.BiFunction
 
 import redis.{ByteStringFormatter, RedisClient}
 
-import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.util.{Failure, Success, Try}
 
@@ -23,32 +22,21 @@ class RedisUpdateConcurrencyHandler[K, T](val r: RedisClient,
                                      loadedValueStorer: (K, Future[T]) => Future[_],
                                      keyPrefixer: K => String): Future[Option[T]] = {
     val (newClientPromise, loadIsInProgressAlready) = storePromiseForThisRequest(key)
+    val prefixKey = keyPrefixer(key)
     if (loadIsInProgressAlready) {
+      logger.debug(s"Load already in progress for key $prefixKey, waiting to be resolved.")
       newClientPromise.future
     } else {
-      val prefixKey = keyPrefixer(key)
-      val lockKey = prefixKey + "-lock"
-      r.set(lockKey, "LOCKED", exSeconds = Some(cacheItemLockMaxDurationSeconds), NX = true).flatMap { lockObtained =>
-        if (lockObtained) {
-          logger.debug(s"Successfully acquired update lock of $lockKey")
-          r.get(prefixKey).onComplete {
-            case Success(found@Some(_)) =>
-              logger.debug(s"Value with $prefixKey had appeared in cache, no need to retrieve it.")
-              resolvePromisesWaitingForValueFromCache(key, Success(found))
-              removeCacheUpdateLock(lockKey)
-            case Success(None) =>
-              logger.debug(s"Starting retrieval of $prefixKey with loader function.")
-              retrieveNewvalueWithLoader(key, loader, loadedValueStorer, lockKey)
-            case Failure(e) => newClientPromise.failure(e)
-          }
-        } else {
-          logger.debug(s"Could not acquire $lockKey, waiting patiently for my promise to be resolved. We're ${waitingPromises.asScala.get(key).map(_.size).getOrElse(0)} in total waiting")
-        }
-        newClientPromise.future
-      }.recoverWith { case e =>
-        logger.error(s"Error when obtaining lock $lockKey", e)
-        Future.failed(e)
+      r.get(prefixKey).onComplete {
+        case Success(found@Some(_)) =>
+          logger.debug(s"Value with $prefixKey had appeared in cache, no need to retrieve it.")
+          resolvePromisesWaitingForValueFromCache(key, Success(found), removeWaiters = true)
+        case Success(None) =>
+          logger.debug(s"Starting retrieval of $prefixKey with loader function.")
+          retrieveNewvalueWithLoader(key, loader, loadedValueStorer)
+        case Failure(e) => newClientPromise.failure(e)
       }
+      newClientPromise.future
     }
   }
 
@@ -76,54 +64,38 @@ class RedisUpdateConcurrencyHandler[K, T](val r: RedisClient,
 
   private def retrieveNewvalueWithLoader(key: K,
                                          loader: K => Future[Option[T]],
-                                         loadedValueStorer: (K, Future[T]) => Future[_],
-                                         lockKey: String): Unit = {
+                                         loadedValueStorer: (K, Future[T]) => Future[_]): Unit = {
     val loadingFuture = loader(key)
     loadingFuture.onComplete { result =>
       if (result.isSuccess) {
         result.get match {
           case Some(foundItem) =>
             loadedValueStorer(key, Future.successful(foundItem)).onComplete { _ =>
-              resolvePromisesWaitingForValueFromCache(key, result, failIfNobodyWaiting = false)
-              removeCacheUpdateLock(lockKey)
+              resolvePromisesWaitingForValueFromCache(key, result, removeWaiters = true)
             }
           case None =>
-            removeCacheUpdateLock(lockKey)
+            resolvePromisesWaitingForValueFromCache(key, result, removeWaiters = true)
         }
       } else {
-        removeCacheUpdateLock(lockKey)
+        resolvePromisesWaitingForValueFromCache(key, result, removeWaiters = true)
       }
-      resolvePromisesWaitingForValueFromCache(key, result)
+      resolvePromisesWaitingForValueFromCache(key, result, removeWaiters = false)
     }
   }
 
-  private def resolvePromisesWaitingForValueFromCache(key: K, result: Try[Option[T]], failIfNobodyWaiting: Boolean = true): Unit = {
-    val updateFunction = new BiFunction[K, List[Promise[Option[T]]], List[Promise[Option[T]]]] {
-      override def apply(key: K, promisesWaitingForResult: List[Promise[Option[T]]]): List[Promise[Option[T]]] = {
-        if (promisesWaitingForResult != null) {
-          logger.debug(s"Resolving promises for key $key: ${promisesWaitingForResult.size}")
-          promisesWaitingForResult.foreach { _.complete(result) }
-        } else {
-          if (failIfNobodyWaiting) {
-            throw new IllegalStateException(s"Nobody waiting for results of $key , got result $result")
-          } else {
-            logger.debug(s"Nobody waiting for results of $key, got result $result")
-          }
-        }
-        null
+  private def resolvePromisesWaitingForValueFromCache(key: K, result: Try[Option[T]], removeWaiters: Boolean): Unit = {
+    val resolveWaiters: List[Promise[Option[T]]] => Unit = { promisesWaitingForResult =>
+      if (promisesWaitingForResult != null) {
+        logger.debug(s"Resolving promises for key $key: ${promisesWaitingForResult.size}")
+        promisesWaitingForResult.foreach { _.tryComplete(result) }
+      } else {
+        logger.debug(s"Nobody waiting for results of $key, got result $result")
       }
     }
-
-    waitingPromises.compute(key, updateFunction)
-  }
-
-  private def removeCacheUpdateLock(lockKey: String): Unit = {
-    val removalOfLock = r.del(lockKey)
-    removalOfLock.onSuccess { case _ =>
-      logger.debug(s"Successfully removed update lock $lockKey")
-    }
-    removalOfLock.onFailure { case e: Throwable =>
-      logger.error(s"Could not remove update lock $lockKey", e)
+    if (removeWaiters) {
+      resolveWaiters(waitingPromises.remove(key))
+    } else {
+      resolveWaiters(waitingPromises.get(key))
     }
   }
 }

--- a/src/main/scala/fi/vm/sade/hakurekisteri/integration/cache/RedisUpdateConcurrencyHandler.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/integration/cache/RedisUpdateConcurrencyHandler.scala
@@ -31,7 +31,7 @@ class RedisUpdateConcurrencyHandler[K, T](val r: RedisClient,
           Future.successful(result)
         case None =>
           logger.debug(s"Starting retrieval of $prefixKey with loader function.")
-          retrieveNewvalueWithLoader(key, loader, loadedValueStorer)
+          retrieveNewValueWithLoader(key, loader, loadedValueStorer)
       }.onComplete(resolveWaiters(key, _, waitingPromises.remove(key)))
     }
     newClientPromise.future
@@ -59,7 +59,7 @@ class RedisUpdateConcurrencyHandler[K, T](val r: RedisClient,
     (newClientPromise, otherPromises.nonEmpty)
   }
 
-  private def retrieveNewvalueWithLoader(key: K,
+  private def retrieveNewValueWithLoader(key: K,
                                          loader: K => Future[Option[T]],
                                          loadedValueStorer: (K, Future[T]) => Future[_]): Future[Option[T]] = {
     val loadingFuture = loader(key)

--- a/src/main/scala/fi/vm/sade/hakurekisteri/integration/cache/RedisUpdateConcurrencyHandler.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/integration/cache/RedisUpdateConcurrencyHandler.scala
@@ -34,7 +34,8 @@ class RedisUpdateConcurrencyHandler[K, T](val r: RedisClient,
         case Success(None) =>
           logger.debug(s"Starting retrieval of $prefixKey with loader function.")
           retrieveNewvalueWithLoader(key, loader, loadedValueStorer)
-        case Failure(e) => newClientPromise.failure(e)
+        case failure@Failure(e) =>
+          resolvePromisesWaitingForValueFromCache(key, failure, removeWaiters = true)
       }
       newClientPromise.future
     }

--- a/src/main/scala/fi/vm/sade/hakurekisteri/integration/cache/RedisUpdateConcurrencyHandler.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/integration/cache/RedisUpdateConcurrencyHandler.scala
@@ -25,7 +25,6 @@ class RedisUpdateConcurrencyHandler[K, T](val r: RedisClient,
     val prefixKey = keyPrefixer(key)
     if (loadIsInProgressAlready) {
       logger.debug(s"Load already in progress for key $prefixKey, waiting to be resolved.")
-      newClientPromise.future
     } else {
       r.get(prefixKey).onComplete {
         case Success(found@Some(_)) =>
@@ -37,8 +36,8 @@ class RedisUpdateConcurrencyHandler[K, T](val r: RedisClient,
         case failure@Failure(e) =>
           resolvePromisesWaitingForValueFromCache(key, failure, removeWaiters = true)
       }
-      newClientPromise.future
     }
+    newClientPromise.future
   }
 
   private def storePromiseForThisRequest(key: K): (Promise[Option[T]], Boolean) = {

--- a/src/main/scala/fi/vm/sade/hakurekisteri/integration/cache/RedisUpdateConcurrencyHandler.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/integration/cache/RedisUpdateConcurrencyHandler.scala
@@ -54,7 +54,7 @@ class RedisUpdateConcurrencyHandler[K, T](val r: RedisClient,
 
   private def storePromiseForThisRequest(key: K): (Promise[Option[T]], Boolean) = {
     logger.debug("Adding new client promise:")
-    val updateFunction: BiFunction[_ >: K, _ >: List[Promise[Option[T]]], _ <: List[Promise[Option[T]]]] = new BiFunction[K, List[Promise[Option[T]]], List[Promise[Option[T]]]] {
+    val updateFunction = new BiFunction[K, List[Promise[Option[T]]], List[Promise[Option[T]]]] {
       override def apply(key: K, promises: List[Promise[Option[T]]]): List[Promise[Option[T]]] = {
         val myPromise = Promise[Option[T]]
         if (promises == null) {
@@ -98,7 +98,7 @@ class RedisUpdateConcurrencyHandler[K, T](val r: RedisClient,
   }
 
   private def resolvePromisesWaitingForValueFromCache(key: K, result: Try[Option[T]], failIfNobodyWaiting: Boolean = true): Unit = {
-    val updateFunction: BiFunction[_ >: K, _ >: List[Promise[Option[T]]], _ <: List[Promise[Option[T]]]] = new BiFunction[K, List[Promise[Option[T]]], List[Promise[Option[T]]]] {
+    val updateFunction = new BiFunction[K, List[Promise[Option[T]]], List[Promise[Option[T]]]] {
       override def apply(key: K, promisesWaitingForResult: List[Promise[Option[T]]]): List[Promise[Option[T]]] = {
         if (promisesWaitingForResult != null) {
           logger.debug(s"Resolving promises for key $key: ${promisesWaitingForResult.size}")

--- a/src/main/scala/fi/vm/sade/hakurekisteri/integration/cache/RedisUpdateConcurrencyHandler.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/integration/cache/RedisUpdateConcurrencyHandler.scala
@@ -9,8 +9,7 @@ import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.util.{Failure, Success, Try}
 
 class RedisUpdateConcurrencyHandler[K, T](val r: RedisClient,
-                                          limitOfWaitingClientsToLog: Int,
-                                          cacheItemLockMaxDurationSeconds: Int)
+                                          limitOfWaitingClientsToLog: Int)
                                          (implicit val byteStringFormatter: ByteStringFormatter[T],
                                            implicit val executionContext: ExecutionContext) {
 

--- a/src/main/scala/fi/vm/sade/hakurekisteri/integration/cache/monadCache.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/integration/cache/monadCache.scala
@@ -1,9 +1,15 @@
 package fi.vm.sade.hakurekisteri.integration.cache
 
+import java.util.Collections
+import java.util.concurrent.Semaphore
+
+import scala.collection.concurrent.TrieMap
+import scala.collection.mutable
 import scala.compat.Platform
 import scala.concurrent.duration._
-import scala.concurrent.Future
+import scala.concurrent.{Future, Promise}
 import scala.language.higherKinds
+import scala.collection.JavaConverters._
 
 trait MonadCache[F[_], K, T] {
 
@@ -15,14 +21,80 @@ trait MonadCache[F[_], K, T] {
 
   def get(key: K): F[T]
 
+  def get(key: K, loader: K => F[Option[T]]): F[Option[T]]
+
+  def toOption(value: F[T]): F[Option[T]]
+
   protected def k(key: K, prefix:String) = s"${prefix}:${key}"
 }
 
-class InMemoryFutureCache[K, T](val exp: Long = 60.minutes.toMillis) extends InMemoryMonadCache[Future, K, T](exp)
+class InMemoryFutureCache[K, T](val exp: Long = 60.minutes.toMillis) extends InMemoryMonadCache[Future, K, T](exp) {
+  private val commonLockHandlingSemaphore = new Semaphore(1)
+  private val loadingLocks: mutable.Map[K, Semaphore] = TrieMap[K, Semaphore]()
+  private val waitingPromises: mutable.Map[K, java.util.List[Promise[Option[T]]]] = TrieMap[K, java.util.List[Promise[Option[T]]]]()
+
+  import scala.concurrent.ExecutionContext.Implicits.global
+  override def toOption(value: Future[T]): Future[Option[T]] = value.map(Some(_))
+
+  override def get(key: K, loader: K => Future[Option[T]]): Future[Option[T]] = {
+    if (contains(key)) {
+      toOption(get(key))
+    } else {
+      commonLockHandlingSemaphore.acquire()
+      try {
+        retrieveNewValueWithLoader(key, loader)
+      } finally {
+        commonLockHandlingSemaphore.release()
+      }
+    }
+  }
+
+  private def retrieveNewValueWithLoader(key: K, loader: K => Future[Option[T]]) = {
+    val loadingLockOfKey = loadingLocks.getOrElseUpdate(key, { new Semaphore(1) })
+    val promisesOfThisKey = waitingPromises.getOrElseUpdate(key, { createSynchonizedList })
+    val newClientPromise: Promise[Option[T]] = Promise[Option[T]]
+    promisesOfThisKey.add(newClientPromise)
+    if (loadingLockOfKey.availablePermits() > 0) {
+      loadingLockOfKey.acquire()
+      if (contains(key)) {
+        loadingLockOfKey.release()
+        toOption(get(key))
+      } else {
+        val loadingFuture: Future[Option[T]] = loader(key)
+        loadingFuture.onComplete { result =>
+          commonLockHandlingSemaphore.acquire()
+          try {
+            if (result.isSuccess) {
+              result.get.foreach(foundItem => storeToCache(key, foundItem))
+            }
+            waitingPromises.remove(key) match {
+              case Some(promisesWaitingForResult) => promisesWaitingForResult.asScala.foreach(_.complete(result))
+              case None => throw new IllegalStateException(s"Nobody waiting for results of $key , got result $result")
+            }
+          } finally {
+            loadingLockOfKey.release()
+            commonLockHandlingSemaphore.release()
+          }
+        }
+        loadingFuture
+      }
+    } else {
+      newClientPromise.future
+    }
+  }
+
+  private def storeToCache(key: K, found: T): Unit = {
+    this.+(key, Future.successful(found))
+  }
+
+  private def createSynchonizedList: java.util.List[Promise[Option[T]]] = {
+    Collections.synchronizedList(new java.util.ArrayList[Promise[Option[T]]]())
+  }
+}
 
 case class Cacheable[F[_], T](inserted: Long = Platform.currentTime, accessed: Long = Platform.currentTime, f: F[T])
 
-class InMemoryMonadCache[F[_], K, T](val expirationDurationMillis: Long = 60.minutes.toMillis) extends MonadCache[F, K, T] {
+abstract class InMemoryMonadCache[F[_], K, T](val expirationDurationMillis: Long = 60.minutes.toMillis) extends MonadCache[F, K, T] {
 
   private var cache: Map[K, Cacheable[F, T]] = Map()
 
@@ -40,6 +112,14 @@ class InMemoryMonadCache[F[_], K, T](val expirationDurationMillis: Long = 60.min
     val cached = cache(key)
     cache = cache + (key -> Cacheable[F, T](inserted = cached.inserted, f = cached.f))
     cached.f
+  }
+
+  def get(key: K, loader: K => F[Option[T]]): F[Option[T]] = {
+    if (cache.contains(key)) {
+      toOption(get(key))
+    } else {
+        loader(key)
+    }
   }
 
   def inUse(key: K): Boolean = cache.contains(key) && (cache(key).accessed + expirationDurationMillis) > Platform.currentTime

--- a/src/main/scala/fi/vm/sade/hakurekisteri/integration/koodisto/KoodistoActor.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/integration/koodisto/KoodistoActor.scala
@@ -48,10 +48,7 @@ class KoodistoActor(restClient: VirkailijaRestClient, config: Config, cacheFacto
         .map(koodit => KoodistoKoodiArvot(koodistoUri, koodit.map(_.koodiArvo)))
         .map(Some(_))
     }
-    koodiArvotCache.get(koodistoUri, loader).flatMap {
-      case Some(koodistoArvot) => Future.successful(koodistoArvot)
-      case None => Future.failed(new IllegalArgumentException(s"Could not find koodistoarvot for koodistoUri '$koodistoUri'"))
-    }
+    koodiArvotCache.get(koodistoUri, loader).map(_.get)
   }
 
   def notFound(t: Throwable): Boolean = t match {
@@ -68,10 +65,7 @@ class KoodistoActor(restClient: VirkailijaRestClient, config: Config, cacheFacto
       }
       koodi.map(Option(_))
     }
-    koodiCache.get(koodiUri, loader).flatMap {
-      case Some(found) => Future.successful(found)
-      case None => Future.failed(new RuntimeException(s"Something went wrong when retrieving koodi $koodiUri from $koodistoUri"))
-    }
+    koodiCache.get(koodiUri, loader).map(_.get)
   }
 
   def getRinnasteinenKoodiArvo(q: GetRinnasteinenKoodiArvoQuery): Future[String] = {

--- a/src/main/scala/fi/vm/sade/hakurekisteri/integration/organisaatio/OrganisaatioActor.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/integration/organisaatio/OrganisaatioActor.scala
@@ -98,7 +98,7 @@ class HttpOrganisaatioActor(organisaatioClient: VirkailijaRestClient,
     if (cache.contains(oid))
       cache.get(oid).map(Some(_))
     else
-      findAndCache(oid)
+      cache.get(oid, findAndCache)
   }
 
   private def findChildOids(parentOid: String): Future[Option[ChildOids]] = {

--- a/src/main/scala/fi/vm/sade/hakurekisteri/integration/organisaatio/OrganisaatioActor.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/integration/organisaatio/OrganisaatioActor.scala
@@ -42,9 +42,11 @@ class HttpOrganisaatioActor(organisaatioClient: VirkailijaRestClient,
 
   private def saveOrganisaatiot(s: Seq[Organisaatio]): Unit = {
     s.foreach(org => {
-      if(!cache.contains(org.oid))
-        cache + (org.oid, Future.successful(org))
-
+      cache.contains(org.oid).onComplete {
+        case Success(false) => cache + (org.oid, Future.successful(org))
+        case Success(true) =>
+        case scala.util.Failure(t) => log.error(t, s"Exception when checking contains for ${org.oid}")
+      }
       if (org.oppilaitosKoodi.isDefined)
         oppilaitoskoodiIndex = oppilaitoskoodiIndex + (org.oppilaitosKoodi.get -> org.oid)
 

--- a/src/main/scala/fi/vm/sade/hakurekisteri/integration/organisaatio/OrganisaatioActor.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/integration/organisaatio/OrganisaatioActor.scala
@@ -43,7 +43,7 @@ class HttpOrganisaatioActor(organisaatioClient: VirkailijaRestClient,
   private def saveOrganisaatiot(s: Seq[Organisaatio]): Unit = {
     s.foreach(org => {
       cache.contains(org.oid).onComplete {
-        case Success(false) => cache + (org.oid, Future.successful(org))
+        case Success(false) => cache + (org.oid, org)
         case Success(true) =>
         case scala.util.Failure(t) => log.error(t, s"Exception when checking contains for ${org.oid}")
       }
@@ -55,7 +55,7 @@ class HttpOrganisaatioActor(organisaatioClient: VirkailijaRestClient,
     })
   }
   private def saveChildOids(parentOid: String, childOids: ChildOids): Unit = {
-    childOidCache + (parentOid, Future.successful(childOids))
+    childOidCache + (parentOid, childOids)
   }
 
   private def findAndCacheChildOids(parentOid: String): Future[Option[ChildOids]] = {

--- a/src/main/scala/fi/vm/sade/hakurekisteri/integration/organisaatio/OrganisaatioActor.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/integration/organisaatio/OrganisaatioActor.scala
@@ -95,17 +95,11 @@ class HttpOrganisaatioActor(organisaatioClient: VirkailijaRestClient,
   }
 
   private def findByOid(oid: String): Future[Option[Organisaatio]] = {
-    if (cache.contains(oid))
-      cache.get(oid).map(Some(_))
-    else
-      cache.get(oid, findAndCache)
+    cache.get(oid, findAndCache)
   }
 
   private def findChildOids(parentOid: String): Future[Option[ChildOids]] = {
-    if (childOidCache.contains(parentOid))
-      childOidCache.get(parentOid).map(Some(_))
-    else
-      findAndCacheChildOids(parentOid)
+    childOidCache.get(parentOid, _ => findAndCacheChildOids(parentOid))
   }
   private def findByOppilaitoskoodi(koodi: String): Future[Option[Organisaatio]] = {
     oppilaitoskoodiIndex.get(koodi) match {

--- a/src/main/scala/fi/vm/sade/hakurekisteri/integration/organisaatio/OrganisaatioActor.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/integration/organisaatio/OrganisaatioActor.scala
@@ -97,7 +97,7 @@ class HttpOrganisaatioActor(organisaatioClient: VirkailijaRestClient,
   }
 
   private def findByOid(oid: String): Future[Option[Organisaatio]] = {
-    cache.get(oid, findAndCache)
+    cache.get(oid, o => findAndCache(o))
   }
 
   private def findChildOids(parentOid: String): Future[Option[ChildOids]] = {

--- a/src/main/scala/fi/vm/sade/hakurekisteri/integration/tarjonta/TarjontaActor.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/integration/tarjonta/TarjontaActor.scala
@@ -98,10 +98,10 @@ class TarjontaActor(restClient: VirkailijaRestClient, config: Config, cacheFacto
   }
 
   def getKomo(oid: String): Future[KomoResponse] = {
-    val loader = restClient.readObject[TarjontaResultResponse[Option[Komo]]]("tarjonta-service.komo", oid)(200, maxRetries)
+    val loader: String => Future[Option[KomoResponse]] = o => restClient.readObject[TarjontaResultResponse[Option[Komo]]]("tarjonta-service.komo", oid)(200, maxRetries)
       .map(res => KomoResponse(oid, res.result))
       .map(Option(_))
-    komoCache.get(oid, o => loader).flatMap {
+    komoCache.get(oid, loader).flatMap {
       case Some(foundKomo) => Future.successful(foundKomo)
       case None => Future.failed(new RuntimeException(s"Could not retrieve komo $oid"))
     }

--- a/src/main/scala/fi/vm/sade/hakurekisteri/integration/tarjonta/TarjontaActor.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/integration/tarjonta/TarjontaActor.scala
@@ -90,19 +90,18 @@ class TarjontaActor(restClient: VirkailijaRestClient, config: Config, cacheFacto
     case q: GetKomoQuery => getKomo(q.oid) pipeTo sender
     case q: HakukohdeQuery => getHakukohde(q.oid) pipeTo sender
     case GetHautQuery => getHaut pipeTo sender
-    case oid: HakukohdeOid => getHakukohteenKoulutukset(oid) pipeTo sender
+    case oid: HakukohdeOid => getHakukohteenKoulutuksetViaCache(oid) pipeTo sender
   }
-  
+
   def searchKomo(koulutus: String): Future[Seq[Komo]] = {
     restClient.readObject[TarjontaResultResponse[Seq[Komo]]]("tarjonta-service.komo.search", koulutus)(200, maxRetries).map(_.result)
   }
 
   def getKomo(oid: String): Future[KomoResponse] = {
-    if (komoCache.contains(oid)) komoCache.get(oid)
-    else {
-      val f = restClient.readObject[TarjontaResultResponse[Option[Komo]]]("tarjonta-service.komo", oid)(200, maxRetries).map(res => KomoResponse(oid, res.result))
-      komoCache + (oid, f)
-      f
+    val f = restClient.readObject[TarjontaResultResponse[Option[Komo]]]("tarjonta-service.komo", oid)(200, maxRetries).map(res => KomoResponse(oid, res.result))
+    komoCache.get(oid, o => f.map(Option(_))).flatMap {
+      case Some(foundKomo) => Future.successful(foundKomo)
+      case None => Future.failed(new RuntimeException(s"Could not retrieve komo $oid"))
     }
   }
 
@@ -133,29 +132,29 @@ class TarjontaActor(restClient: VirkailijaRestClient, config: Config, cacheFacto
   }
 
   def getHakukohde(oid: String): Future[Option[Hakukohde]] = {
-    if (hakukohdeCache.contains(oid)) {
-      hakukohdeCache.get(oid)
-    } else {
-      val hakukohde = restClient.readObject[TarjontaResultResponse[Option[Hakukohde]]]("tarjonta-service.hakukohde", oid)(200, maxRetries).map(r => r.result)
-      hakukohdeCache + (oid, hakukohde)
-      hakukohde
+    val loader: String => Future[Option[Option[Hakukohde]]] = { hakukohdeOid =>
+      restClient.readObject[TarjontaResultResponse[Option[Hakukohde]]]("tarjonta-service.hakukohde", hakukohdeOid)(200, maxRetries).map(r => r.result).map(Option(_))
     }
+
+    hakukohdeCache.get(oid, loader).map(_.get)
   }
 
   def getHakukohteenkoulutukset(oids: Seq[String]): Future[Seq[Hakukohteenkoulutus]] = Future.sequence(oids.map(getKoulutus)).map(_.foldLeft(Seq[Hakukohteenkoulutus]())(_ ++ _))
 
-  def getHakukohteenKoulutukset(hk: HakukohdeOid): Future[HakukohteenKoulutukset] = {
-    if (koulutusCache.contains(hk.oid)) koulutusCache.get(hk.oid)
-    else {
-      val fh: Future[Option[Hakukohde]] = restClient.readObject[TarjontaResultResponse[Option[Hakukohde]]]("tarjonta-service.hakukohde", hk.oid)(200, maxRetries).map(r => r.result)
-      val hks: Future[HakukohteenKoulutukset] = fh.flatMap {
-        case None => Future.failed(HakukohdeNotFoundException(s"hakukohde not found with oid ${hk.oid}"))
-        case Some(h) => for (
-          hakukohteenkoulutukset: Seq[Hakukohteenkoulutus] <- getHakukohteenkoulutukset(h.hakukohdeKoulutusOids)
-        ) yield HakukohteenKoulutukset(h.oid, h.ulkoinenTunniste, hakukohteenkoulutukset)
-      }
-      koulutusCache + (hk.oid, hks)
-      hks
+  def getHakukohteenKoulutuksetViaCache(hk: HakukohdeOid): Future[HakukohteenKoulutukset] = {
+    val loader: String => Future[Option[HakukohteenKoulutukset]] = hakukohdeOid => {
+          val fh: Future[Option[Hakukohde]] = restClient.readObject[TarjontaResultResponse[Option[Hakukohde]]]("tarjonta-service.hakukohde", hk.oid)(200, maxRetries).map(r => r.result)
+          fh.flatMap {
+            case None => Future.failed(HakukohdeNotFoundException(s"hakukohde not found with oid ${hk.oid}"))
+            case Some(h) => for (
+              hakukohteenkoulutukset: Seq[Hakukohteenkoulutus] <- getHakukohteenkoulutukset(h.hakukohdeKoulutusOids)
+            ) yield Some(HakukohteenKoulutukset(h.oid, h.ulkoinenTunniste, hakukohteenkoulutukset))
+          }
+        }
+
+    koulutusCache.get(hk.oid, loader).flatMap {
+      case Some(foundHakukohteenKoulutukset) => Future.successful(foundHakukohteenKoulutukset)
+      case None => Future.failed(new RuntimeException(s"Could not retrieve koulutukset for Hakukohde ${hk.oid}"))
     }
   }
 }

--- a/src/main/scala/fi/vm/sade/hakurekisteri/integration/valintatulos/ValintaTulosActor.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/integration/valintatulos/ValintaTulosActor.scala
@@ -93,7 +93,7 @@ class ValintaTulosActor(client: VirkailijaRestClient,
       } pipeTo self
 
     case CacheResponse(haku, tulos) =>
-      cache + (haku, Future.successful(tulos))
+      cache + (haku, tulos)
       calling = false
       self ! UpdateNext
 

--- a/src/main/scala/fi/vm/sade/hakurekisteri/web/hakija/HakijaResourceSupport.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/web/hakija/HakijaResourceSupport.scala
@@ -39,6 +39,7 @@ trait HakijaResourceSupport extends ApiFormats with QueryLogging { this: HakuJaV
     new AsyncResult() {
       override implicit def timeout: Duration = 120.seconds
       val is = process
+      process.onFailure { case e: Throwable => logger.error(e, "Exception thrown from async processing") }
     }
   }
 }

--- a/src/main/scala/fi/vm/sade/hakurekisteri/web/hakija/HakijaResourceSupport.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/web/hakija/HakijaResourceSupport.scala
@@ -1,16 +1,15 @@
 package fi.vm.sade.hakurekisteri.web.hakija
 
-import akka.util.Timeout
 import fi.vm.sade.hakurekisteri.web.HakuJaValintarekisteriStack
-import fi.vm.sade.hakurekisteri.web.rest.support.{QueryLogging, ApiFormat}
 import fi.vm.sade.hakurekisteri.web.rest.support.ApiFormat._
-import org.scalatra.{AsyncResult, ApiFormats, ScalatraServlet, ScalatraBase}
+import fi.vm.sade.hakurekisteri.web.rest.support.{ApiFormat, QueryLogging}
+import org.scalatra.{ApiFormats, AsyncResult}
 
 import scala.compat.Platform
 import scala.concurrent.Future
-import scala.concurrent.duration.Duration
+import scala.concurrent.duration.{Duration, _}
 import scala.util.Try
-import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global
 
 
 trait HakijaResourceSupport extends ApiFormats with QueryLogging { this: HakuJaValintarekisteriStack =>

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -7,3 +7,4 @@ log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
 log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
 log4j.appender.CONSOLE.layout.ConversionPattern=%d{yyyy-MM-dd'T'HH:mm:ss.SSSX} %5p %c{1}:%L - %m%n
 
+log4j.logger.fi.vm.sade.hakurekisteri.integration.cache=DEBUG

--- a/src/test/resources/mock-data/organisaatio/organisaatio-1.2.246.562.10.165466228888.json
+++ b/src/test/resources/mock-data/organisaatio/organisaatio-1.2.246.562.10.165466228888.json
@@ -1,0 +1,5 @@
+{
+  "oid": "1.2.246.562.10.165466228888",
+  "nimi": {"fi": "kasikasikasikasi"},
+  "oppilaitosKoodi": "88888"
+}

--- a/src/test/scala/fi/vm/sade/hakurekisteri/integration/FutureCacheSpec.scala
+++ b/src/test/scala/fi/vm/sade/hakurekisteri/integration/FutureCacheSpec.scala
@@ -26,7 +26,7 @@ class FutureCacheSpec extends FlatSpec with Matchers {
 
     cache + (cacheKey, cacheEntryValue)
 
-    cache.getCache(cacheKey).f should be (cacheEntry)
+    Await.result(cache.getCache(cacheKey).f, 1.second) should be (cacheEntryValue)
   }
 
   it should "set inserted time for the cached entry" in {

--- a/src/test/scala/fi/vm/sade/hakurekisteri/integration/FutureCacheSpec.scala
+++ b/src/test/scala/fi/vm/sade/hakurekisteri/integration/FutureCacheSpec.scala
@@ -18,12 +18,13 @@ class FutureCacheSpec extends FlatSpec with Matchers {
   behavior of "FutureCache"
 
   val cacheKey = "foo"
-  val cacheEntry = Future.successful("bar")
+  private val cacheEntryValue = "bar"
+  val cacheEntry = Future.successful(cacheEntryValue)
 
   it should "add an entry to cache" in {
     val cache = newCache()
 
-    cache + (cacheKey, cacheEntry)
+    cache + (cacheKey, cacheEntryValue)
 
     cache.getCache(cacheKey).f should be (cacheEntry)
   }
@@ -31,7 +32,7 @@ class FutureCacheSpec extends FlatSpec with Matchers {
   it should "set inserted time for the cached entry" in {
     val cache = newCache()
 
-    cache + (cacheKey, cacheEntry)
+    cache + (cacheKey, cacheEntryValue)
 
     cache.getCache(cacheKey).inserted should be <= Platform.currentTime
   }
@@ -39,7 +40,7 @@ class FutureCacheSpec extends FlatSpec with Matchers {
   it should "set accessed time for the cached entry during add" in {
     val cache = newCache()
 
-    cache + (cacheKey, cacheEntry)
+    cache + (cacheKey, cacheEntryValue)
 
     cache.getCache(cacheKey).accessed should be <= Platform.currentTime
   }
@@ -47,7 +48,7 @@ class FutureCacheSpec extends FlatSpec with Matchers {
   it should "update accessed time during get" in {
     val cache = newCache()
 
-    cache + (cacheKey, cacheEntry)
+    cache + (cacheKey, cacheEntryValue)
 
     val accessed = cache.getCache(cacheKey).accessed
 
@@ -61,13 +62,13 @@ class FutureCacheSpec extends FlatSpec with Matchers {
   it should "update inserted time for an existing entry during add" in {
     val cache = newCache()
 
-    cache + (cacheKey, cacheEntry)
+    cache + (cacheKey, cacheEntryValue)
 
     val inserted = cache.getCache(cacheKey).inserted
 
     Thread.sleep(100)
 
-    cache + (cacheKey, cacheEntry)
+    cache + (cacheKey, cacheEntryValue)
 
     cache.getCache(cacheKey).inserted should be > inserted
   }
@@ -75,13 +76,13 @@ class FutureCacheSpec extends FlatSpec with Matchers {
   it should "retain accessed time for an existing entry during add" in {
     val cache = newCache()
 
-    cache + (cacheKey, cacheEntry)
+    cache + (cacheKey, cacheEntryValue)
 
     val accessed = cache.getCache(cacheKey).accessed
 
     Thread.sleep(100)
 
-    cache + (cacheKey, cacheEntry)
+    cache + (cacheKey, cacheEntryValue)
 
     cache.getCache(cacheKey).accessed should be (accessed)
   }
@@ -89,7 +90,7 @@ class FutureCacheSpec extends FlatSpec with Matchers {
   it should "remove an entry from cache" in {
     val cache = newCache()
 
-    cache + (cacheKey, cacheEntry)
+    cache + (cacheKey, cacheEntryValue)
 
     cache - cacheKey
 
@@ -99,8 +100,8 @@ class FutureCacheSpec extends FlatSpec with Matchers {
   it should "return the size of the cache" in {
     val cache = newCache()
 
-    cache + (cacheKey, cacheEntry)
-    cache + ("foo2", Future.successful("bar2"))
+    cache + (cacheKey, cacheEntryValue)
+    cache + ("foo2", cacheEntryValue + "2")
 
     cache.size should be (2)
   }
@@ -108,7 +109,7 @@ class FutureCacheSpec extends FlatSpec with Matchers {
   it should "tell if cache contains a key" in {
     val cache = newCache()
 
-    cache + (cacheKey, cacheEntry)
+    cache + (cacheKey, cacheEntryValue)
 
     Await.result(cache.contains(cacheKey), 1.second) should be(true)
   }
@@ -116,7 +117,7 @@ class FutureCacheSpec extends FlatSpec with Matchers {
   it should "tell if an entry is no longer live" in {
     val cache = newCache(0)
 
-    cache + (cacheKey, cacheEntry)
+    cache + (cacheKey, cacheEntryValue)
 
     Await.result(cache.contains(cacheKey), 1.second) should be(false)
   }

--- a/src/test/scala/fi/vm/sade/hakurekisteri/integration/FutureCacheSpec.scala
+++ b/src/test/scala/fi/vm/sade/hakurekisteri/integration/FutureCacheSpec.scala
@@ -5,8 +5,8 @@ import fi.vm.sade.hakurekisteri.integration.cache.InMemoryFutureCache
 import org.scalatest.{FlatSpec, Matchers}
 
 import scala.compat.Platform
-import scala.concurrent.Future
 import scala.concurrent.duration._
+import scala.concurrent.{Await, Future}
 
 class FutureCacheSpec extends FlatSpec with Matchers {
 
@@ -110,7 +110,7 @@ class FutureCacheSpec extends FlatSpec with Matchers {
 
     cache + (cacheKey, cacheEntry)
 
-    cache.contains(cacheKey) should be (true)
+    Await.result(cache.contains(cacheKey), 1.second) should be(true)
   }
 
   it should "tell if an entry is no longer live" in {
@@ -118,7 +118,7 @@ class FutureCacheSpec extends FlatSpec with Matchers {
 
     cache + (cacheKey, cacheEntry)
 
-    cache.contains(cacheKey) should be (false)
+    Await.result(cache.contains(cacheKey), 1.second) should be(false)
   }
 
 }

--- a/src/test/scala/fi/vm/sade/hakurekisteri/integration/RedisCacheSpec.scala
+++ b/src/test/scala/fi/vm/sade/hakurekisteri/integration/RedisCacheSpec.scala
@@ -48,7 +48,7 @@ class RedisCacheSpec extends FlatSpec with Matchers with ActorSystemSupport with
 
         Thread.sleep(500)
 
-        cache contains(cacheKey) should be(true)
+        Await.result(cache.contains(cacheKey), 1.second) should be(true)
 
         Await.result(cache get cacheKey, 10.seconds) should be (cacheEntry)
       }
@@ -64,13 +64,13 @@ class RedisCacheSpec extends FlatSpec with Matchers with ActorSystemSupport with
 
         Thread.sleep(500)
 
-        cache contains(cacheKey) should be(true)
+        Await.result(cache.contains(cacheKey), 1.second) should be(true)
 
         cache - cacheKey
 
         Thread.sleep(500)
 
-        cache contains(cacheKey) should be(false)
+        Await.result(cache.contains(cacheKey), 1.second) should be(false)
       }
     )
   }
@@ -89,7 +89,7 @@ class RedisCacheSpec extends FlatSpec with Matchers with ActorSystemSupport with
       implicit system => {
         val cache = redisCacheFactory.getInstance[String,String](3.minutes.toMillis, getClass, "prefix3")
 
-        cache contains(cacheKey) should be(true)
+        Await.result(cache.contains(cacheKey), 1.second) should be(true)
       }
     )
   }
@@ -109,8 +109,8 @@ class RedisCacheSpec extends FlatSpec with Matchers with ActorSystemSupport with
         val cache4 = redisCacheFactory.getInstance[String,String](3.minutes.toMillis, getClass, "prefix4")
         val cache5 =  redisCacheFactory.getInstance[String,String](3.minutes.toMillis, getClass, "prefix5")
 
-        cache5 contains(cacheKey) should be(false)
-        cache4 contains(cacheKey) should be(true)
+        Await.result(cache5.contains(cacheKey), 1.second) should be(false)
+        Await.result(cache4.contains(cacheKey), 1.second) should be(true)
       }
     )
   }
@@ -134,7 +134,7 @@ class RedisCacheSpec extends FlatSpec with Matchers with ActorSystemSupport with
            results.foreach(_ should be(Some(cacheEntry)))
 
            Await.result(cache.get(cacheKey), 1.second) should be (cacheEntry)
-           cache.contains(cacheKey) should be(true)
+           Await.result(cache.contains(cacheKey), 1.second) should be(true)
 
            verify(mockLoader, times(1)).apply(cacheKey)
          }

--- a/src/test/scala/fi/vm/sade/hakurekisteri/integration/RedisCacheSpec.scala
+++ b/src/test/scala/fi/vm/sade/hakurekisteri/integration/RedisCacheSpec.scala
@@ -134,8 +134,9 @@ class RedisCacheSpec extends FlatSpec with Matchers with ActorSystemSupport with
            results should have size concurrencyTestParallelRequestCount
            results.foreach(_ should be(Some(cacheEntry)))
 
-           Await.result(cache.get(cacheKey), 1.second) should be (cacheEntry)
+           Thread.sleep(100)
            Await.result(cache.contains(cacheKey), 1.second) should be(true)
+           Await.result(cache.get(cacheKey), 1.second) should be (cacheEntry)
 
            verify(mockLoader, times(1)).apply(cacheKey)
          }

--- a/src/test/scala/fi/vm/sade/hakurekisteri/integration/RedisCacheSpec.scala
+++ b/src/test/scala/fi/vm/sade/hakurekisteri/integration/RedisCacheSpec.scala
@@ -23,7 +23,6 @@ class RedisCacheSpec extends FlatSpec with Matchers with ActorSystemSupport with
     .addDefault("suoritusrekisteri.cache.redis.enabled", "true")
     .addDefault("suoritusrekisteri.cache.redis.host", "localhost")
     .addDefault("suoritusrekisteri.cache.redis.numberOfWaitersToLog", "5")
-    .addDefault("suoritusrekisteri.cache.redis.cacheItemLockMaxDurationSeconds", "6")
     .addDefault("suoritusrekisteri.cache.redis.cacheHandlingThreadPoolSize", "3")
     .addDefault("suoritusrekisteri.cache.redis.slowRedisRequestThresholdMillis", "0")
     .addDefault("suoritusrekisteri.cache.redis.port", s"${port}"))(system)

--- a/src/test/scala/fi/vm/sade/hakurekisteri/integration/RedisCacheSpec.scala
+++ b/src/test/scala/fi/vm/sade/hakurekisteri/integration/RedisCacheSpec.scala
@@ -130,9 +130,8 @@ class RedisCacheSpec extends FlatSpec with Matchers with ActorSystemSupport with
            results should have size concurrencyTestParallelRequestCount
            results.foreach(_ should be(Some(cacheEntry)))
 
-           cache.contains(cacheKey) should be(true)
-
            Await.result(cache.get(cacheKey), 1.second) should be (cacheEntry)
+           cache.contains(cacheKey) should be(true)
 
            verify(mockLoader, times(1)).apply(cacheKey)
          }

--- a/src/test/scala/fi/vm/sade/hakurekisteri/integration/RedisCacheSpec.scala
+++ b/src/test/scala/fi/vm/sade/hakurekisteri/integration/RedisCacheSpec.scala
@@ -23,6 +23,7 @@ class RedisCacheSpec extends FlatSpec with Matchers with ActorSystemSupport with
     .addDefault("suoritusrekisteri.cache.redis.enabled", "true")
     .addDefault("suoritusrekisteri.cache.redis.host", "localhost")
     .addDefault("suoritusrekisteri.cache.redis.numberOfWaitersToLog", "5")
+    .addDefault("suoritusrekisteri.cache.redis.cacheItemLockMaxDurationSeconds", "6")
     .addDefault("suoritusrekisteri.cache.redis.port", s"${port}"))(system)
 
   override def beforeAll() = {

--- a/src/test/scala/fi/vm/sade/hakurekisteri/integration/RedisCacheSpec.scala
+++ b/src/test/scala/fi/vm/sade/hakurekisteri/integration/RedisCacheSpec.scala
@@ -4,13 +4,17 @@ import akka.actor.ActorSystem
 import fi.vm.sade.hakurekisteri.integration.cache.CacheFactory
 import fi.vm.sade.scalaproperties.OphProperties
 import fi.vm.sade.utils.tcp.PortChecker
-import org.scalatest.{BeforeAndAfterAll, FlatSpec, Ignore, Matchers}
+import org.mockito.Mockito.{times, verify, when}
+import org.mockito.invocation.InvocationOnMock
+import org.mockito.stubbing.Answer
+import org.scalatest.mock.MockitoSugar
+import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
 import redis.embedded.RedisServer
 
-import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
+import scala.concurrent.{Await, Future}
 
-class RedisCacheSpec extends FlatSpec with Matchers with ActorSystemSupport with BeforeAndAfterAll with DispatchSupport {
+class RedisCacheSpec extends FlatSpec with Matchers with ActorSystemSupport with BeforeAndAfterAll with DispatchSupport with MockitoSugar {
 
   val port = PortChecker.findFreeLocalPort
   val redisServer = new RedisServer(port)
@@ -27,6 +31,10 @@ class RedisCacheSpec extends FlatSpec with Matchers with ActorSystemSupport with
   val cacheKey = "foo"
   val cacheEntry = "bar"
   val cacheEntryF = Future.successful(cacheEntry)
+
+  val concurrencyTestLoopCount: Int = 5
+  val concurrencyTestParallelRequestCount: Int = 10
+  val concurrencyTestResultsWaitDuration: Duration = 10.seconds
 
   it should "add an entry to cache" in {
    withSystem(
@@ -102,6 +110,34 @@ class RedisCacheSpec extends FlatSpec with Matchers with ActorSystemSupport with
         cache4 contains(cacheKey) should be(true)
       }
     )
+  }
+
+  it should "only do one backend call per missing value with loader accepting get API" in {
+    1.to(concurrencyTestLoopCount).foreach { counter =>
+      withSystem(
+         implicit system => {
+           val cache = redisCacheFactory.getInstance[String,String](3.minutes.toMillis, getClass, s"prefixLoaderApi$counter")
+
+           val mockLoader: String => Future[Option[String]] = mock[String => Future[Option[String]]]
+           when(mockLoader.apply(cacheKey)).thenAnswer(new Answer[Future[Option[String]]] {
+             override def answer(invocation: InvocationOnMock): Future[Option[String]] = {
+               Thread.sleep(10)
+               Future.successful(Some(cacheEntry))
+             }
+           })
+
+           val results = 1.to(concurrencyTestParallelRequestCount).par.map(_ => cache.get(cacheKey, mockLoader)).map(Await.result(_, concurrencyTestResultsWaitDuration))
+           results should have size concurrencyTestParallelRequestCount
+           results.foreach(_ should be(Some(cacheEntry)))
+
+           cache.contains(cacheKey) should be(true)
+
+           Await.result(cache.get(cacheKey), 1.second) should be (cacheEntry)
+
+           verify(mockLoader, times(1)).apply(cacheKey)
+         }
+       )
+    }
   }
 
   override def afterAll() = {

--- a/src/test/scala/fi/vm/sade/hakurekisteri/integration/RedisCacheSpec.scala
+++ b/src/test/scala/fi/vm/sade/hakurekisteri/integration/RedisCacheSpec.scala
@@ -44,7 +44,7 @@ class RedisCacheSpec extends FlatSpec with Matchers with ActorSystemSupport with
       implicit system => {
         val cache = redisCacheFactory.getInstance[String,String](3.minutes.toMillis, getClass, "prefix1")
 
-        cache + (cacheKey, cacheEntryF)
+        cache + (cacheKey, cacheEntry)
 
         Thread.sleep(500)
 
@@ -60,7 +60,7 @@ class RedisCacheSpec extends FlatSpec with Matchers with ActorSystemSupport with
       implicit system => {
         val cache = redisCacheFactory.getInstance[String, String](3.minutes.toMillis, getClass, "prefix2")
 
-        cache + (cacheKey, cacheEntryF)
+        cache + (cacheKey, cacheEntry)
 
         Thread.sleep(500)
 
@@ -80,7 +80,7 @@ class RedisCacheSpec extends FlatSpec with Matchers with ActorSystemSupport with
       implicit system => {
         val cache = redisCacheFactory.getInstance[String,String](3.minutes.toMillis, getClass, "prefix3")
 
-        cache + (cacheKey, cacheEntryF)
+        cache + (cacheKey, cacheEntry)
 
         Thread.sleep(500)
       }
@@ -99,7 +99,7 @@ class RedisCacheSpec extends FlatSpec with Matchers with ActorSystemSupport with
       implicit system => {
         val cache = redisCacheFactory.getInstance[String,String](3.minutes.toMillis, getClass, "prefix4")
 
-        cache + (cacheKey, cacheEntryF)
+        cache + (cacheKey, cacheEntry)
 
         Thread.sleep(500)
       }

--- a/src/test/scala/fi/vm/sade/hakurekisteri/integration/RedisCacheSpec.scala
+++ b/src/test/scala/fi/vm/sade/hakurekisteri/integration/RedisCacheSpec.scala
@@ -24,6 +24,7 @@ class RedisCacheSpec extends FlatSpec with Matchers with ActorSystemSupport with
     .addDefault("suoritusrekisteri.cache.redis.host", "localhost")
     .addDefault("suoritusrekisteri.cache.redis.numberOfWaitersToLog", "5")
     .addDefault("suoritusrekisteri.cache.redis.cacheItemLockMaxDurationSeconds", "6")
+    .addDefault("suoritusrekisteri.cache.redis.cacheHandlingThreadPoolSize", "3")
     .addDefault("suoritusrekisteri.cache.redis.port", s"${port}"))(system)
 
   override def beforeAll() = {

--- a/src/test/scala/fi/vm/sade/hakurekisteri/integration/RedisCacheSpec.scala
+++ b/src/test/scala/fi/vm/sade/hakurekisteri/integration/RedisCacheSpec.scala
@@ -25,6 +25,7 @@ class RedisCacheSpec extends FlatSpec with Matchers with ActorSystemSupport with
     .addDefault("suoritusrekisteri.cache.redis.numberOfWaitersToLog", "5")
     .addDefault("suoritusrekisteri.cache.redis.cacheItemLockMaxDurationSeconds", "6")
     .addDefault("suoritusrekisteri.cache.redis.cacheHandlingThreadPoolSize", "3")
+    .addDefault("suoritusrekisteri.cache.redis.slowRedisRequestThresholdMillis", "0")
     .addDefault("suoritusrekisteri.cache.redis.port", s"${port}"))(system)
 
   override def beforeAll() = {

--- a/src/test/scala/fi/vm/sade/hakurekisteri/integration/RedisCacheSpec.scala
+++ b/src/test/scala/fi/vm/sade/hakurekisteri/integration/RedisCacheSpec.scala
@@ -22,6 +22,7 @@ class RedisCacheSpec extends FlatSpec with Matchers with ActorSystemSupport with
   def redisCacheFactory(implicit system:ActorSystem) = CacheFactory.apply(new OphProperties()
     .addDefault("suoritusrekisteri.cache.redis.enabled", "true")
     .addDefault("suoritusrekisteri.cache.redis.host", "localhost")
+    .addDefault("suoritusrekisteri.cache.redis.numberOfWaitersToLog", "5")
     .addDefault("suoritusrekisteri.cache.redis.port", s"${port}"))(system)
 
   override def beforeAll() = {

--- a/src/test/scala/fi/vm/sade/hakurekisteri/integration/organisaatio/OrganisaatioActorSpec.scala
+++ b/src/test/scala/fi/vm/sade/hakurekisteri/integration/organisaatio/OrganisaatioActorSpec.scala
@@ -37,7 +37,6 @@ class OrganisaatioActorSpec extends ScalatraFunSuite with Matchers with AsyncAss
           }
         })
 
-    // when(e.request(forUrl("http://localhost/organisaatio-service/rest/organisaatio/99999"))).thenReturn((200, List(), OrganisaatioResults.ysiysiysiysiysi))
     when(e.request(forUrl("http://localhost/organisaatio-service/rest/organisaatio/05127"))).thenReturn((200, List(), OrganisaatioResults.pikkola))
     when(e.request(forUrl("http://localhost/organisaatio-service/rest/organisaatio/1.2.246.562.10.16546622305"))).thenReturn((200, List(), OrganisaatioResults.pikkola))
 

--- a/src/test/scala/fi/vm/sade/hakurekisteri/integration/organisaatio/OrganisaatioActorSpec.scala
+++ b/src/test/scala/fi/vm/sade/hakurekisteri/integration/organisaatio/OrganisaatioActorSpec.scala
@@ -6,28 +6,38 @@ import akka.actor.{ActorRef, ActorSystem, Props}
 import akka.pattern.ask
 import akka.util.Timeout
 import com.ning.http.client.AsyncHttpClient
-import fi.vm.sade.hakurekisteri.{Config, MockCacheFactory, MockConfig}
 import fi.vm.sade.hakurekisteri.integration._
+import fi.vm.sade.hakurekisteri.{MockCacheFactory, MockConfig}
 import org.mockito.Mockito._
+import org.mockito.invocation.InvocationOnMock
+import org.mockito.stubbing.Answer
 import org.scalatest.Matchers
 import org.scalatest.concurrent.AsyncAssertions
 import org.scalatest.mock.MockitoSugar
 import org.scalatest.time.{Millis, Span}
 import org.scalatra.test.scalatest.ScalatraFunSuite
 
-import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.concurrent.duration._
+import scala.concurrent.{Await, ExecutionContext, Future}
 
 class OrganisaatioActorSpec extends ScalatraFunSuite with Matchers with AsyncAssertions with MockitoSugar with DispatchSupport with ActorSystemSupport with LocalhostProperties {
 
   implicit val timeout: Timeout = 60.seconds
+  private var delayMillisForOrganization99999 = 0
   val organisaatioConfig = ServiceConfig(serviceUrl = "http://localhost/organisaatio-service")
 
   def createEndPoint(implicit ec: ExecutionContext) = {
     val e = mock[Endpoint]
 
     when(e.request(forUrl("http://localhost/organisaatio-service/rest/organisaatio/v2/hierarkia/hae?aktiiviset=true&lakkautetut=false&suunnitellut=true"))).thenReturn((200, List(), OrganisaatioResults.hae))
-    when(e.request(forUrl("http://localhost/organisaatio-service/rest/organisaatio/99999"))).thenReturn((200, List(), OrganisaatioResults.ysiysiysiysiysi))
+    when(e.request(forUrl("http://localhost/organisaatio-service/rest/organisaatio/99999"))).thenAnswer(new Answer[(Int, List[Nothing], String)]() {
+          override def answer(invocation: InvocationOnMock): (Int, List[Nothing], String) = {
+            Thread.sleep(delayMillisForOrganization99999)
+            (200, List(), OrganisaatioResults.ysiysiysiysiysi)
+          }
+        })
+
+    // when(e.request(forUrl("http://localhost/organisaatio-service/rest/organisaatio/99999"))).thenReturn((200, List(), OrganisaatioResults.ysiysiysiysiysi))
     when(e.request(forUrl("http://localhost/organisaatio-service/rest/organisaatio/05127"))).thenReturn((200, List(), OrganisaatioResults.pikkola))
     when(e.request(forUrl("http://localhost/organisaatio-service/rest/organisaatio/1.2.246.562.10.16546622305"))).thenReturn((200, List(), OrganisaatioResults.pikkola))
 
@@ -106,9 +116,15 @@ class OrganisaatioActorSpec extends ScalatraFunSuite with Matchers with AsyncAss
         implicit val ec = system.dispatcher
         val (endPoint, organisaatioActor) = initOrganisaatioActor()
 
+        delayMillisForOrganization99999 = 150
+
         organisaatioActor ! Oppilaitos("99999")
 
-        Thread.sleep(100)
+        Thread.sleep(delayMillisForOrganization99999 - 50)
+
+        1.to(10).foreach { _ => organisaatioActor ! Oppilaitos("99999") }
+
+        delayMillisForOrganization99999 = 0
 
         waitFuture((organisaatioActor ? Oppilaitos("99999")).mapTo[OppilaitosResponse])(o => {
           o.oppilaitos.oppilaitosKoodi.get should be ("99999")

--- a/src/test/scala/fi/vm/sade/hakurekisteri/integration/valintatulos/ValintaTulosActorWithRedisSpec.scala
+++ b/src/test/scala/fi/vm/sade/hakurekisteri/integration/valintatulos/ValintaTulosActorWithRedisSpec.scala
@@ -200,10 +200,10 @@ class ValintaTulosActorWithRedisSpec extends ScalatraFunSuite with FutureWaiting
         Thread.sleep(300)
 
         val cache = cacheFactory.getInstance[String, SijoitteluTulos](1111, classOf[ValintaTulosActor], "sijoittelu-tulos")
-        cache.contains("1.2.246.562.29.11") should be(true)
-        cache.contains("1.2.246.562.29.12") should be(true)
-        cache.contains("1.2.246.562.29.13") should be(false)
-        cache.contains("1.2.246.562.29.14") should be(false)
+        Await.result(cache.contains("1.2.246.562.29.11"), 1.second) should be(true)
+        Await.result(cache.contains("1.2.246.562.29.12"), 1.second) should be(true)
+        Await.result(cache.contains("1.2.246.562.29.13"), 1.second) should be(false)
+        Await.result(cache.contains("1.2.246.562.29.14"), 1.second) should be(false)
 
         verify(endPoint).request(forUrl("http://localhost/valinta-tulos-service/haku/1.2.246.562.29.11"))
         verify(endPoint).request(forUrl("http://localhost/valinta-tulos-service/haku/1.2.246.562.29.12"))
@@ -227,10 +227,10 @@ class ValintaTulosActorWithRedisSpec extends ScalatraFunSuite with FutureWaiting
         Thread.sleep(300)
 
         val cache = cacheFactory.getInstance[String, SijoitteluTulos](1111, classOf[ValintaTulosActor], "sijoittelu-tulos")
-        cache.contains("1.2.246.562.29.11") should be(true)
-        cache.contains("1.2.246.562.29.12") should be(true)
-        cache.contains("1.2.246.562.29.13") should be(true)
-        cache.contains("1.2.246.562.29.14") should be(true)
+        Await.result(cache.contains("1.2.246.562.29.11"), 1.second) should be(true)
+        Await.result(cache.contains("1.2.246.562.29.12"), 1.second) should be(true)
+        Await.result(cache.contains("1.2.246.562.29.13"), 1.second) should be(true)
+        Await.result(cache.contains("1.2.246.562.29.14"), 1.second) should be(true)
 
         verify(endPoint, never()).request(forUrl("http://localhost/valinta-tulos-service/haku/1.2.246.562.29.11"))
         verify(endPoint, never()).request(forUrl("http://localhost/valinta-tulos-service/haku/1.2.246.562.29.12"))

--- a/src/test/scala/fi/vm/sade/hakurekisteri/integration/valintatulos/ValintaTulosActorWithRedisSpec.scala
+++ b/src/test/scala/fi/vm/sade/hakurekisteri/integration/valintatulos/ValintaTulosActorWithRedisSpec.scala
@@ -1,12 +1,10 @@
 package fi.vm.sade.hakurekisteri.integration.valintatulos
 
-import java.util.concurrent.TimeUnit
-
 import akka.actor.{ActorSystem, Props}
 import akka.pattern.ask
 import akka.util.Timeout
 import com.ning.http.client.AsyncHttpClient
-import fi.vm.sade.hakurekisteri.{Config, MockCacheFactory, MockConfig}
+import fi.vm.sade.hakurekisteri.MockConfig
 import fi.vm.sade.hakurekisteri.integration._
 import fi.vm.sade.hakurekisteri.integration.cache.CacheFactory
 import fi.vm.sade.hakurekisteri.test.tools.FutureWaiting
@@ -14,14 +12,13 @@ import fi.vm.sade.scalaproperties.OphProperties
 import fi.vm.sade.utils.tcp.PortChecker
 import org.mockito.Mockito
 import org.mockito.Mockito._
-import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, BeforeAndAfterEach, Ignore}
+import org.scalatest.BeforeAndAfterAll
 import org.scalatest.mock.MockitoSugar
 import org.scalatra.test.scalatest.ScalatraFunSuite
 import redis.embedded.RedisServer
 
+import scala.concurrent.Await
 import scala.concurrent.duration._
-import scala.concurrent.{Await, ExecutionContext, Future}
-import scala.util.Try
 
 class ValintaTulosActorWithRedisSpec extends ScalatraFunSuite with FutureWaiting with DispatchSupport with MockitoSugar with ActorSystemSupport with LocalhostProperties with BeforeAndAfterAll {
 
@@ -35,6 +32,7 @@ class ValintaTulosActorWithRedisSpec extends ScalatraFunSuite with FutureWaiting
     .addDefault("suoritusrekisteri.cache.redis.enabled", "true")
     .addDefault("suoritusrekisteri.cache.redis.host", "localhost")
     .addDefault("suoritusrekisteri.cache.redis.numberOfWaitersToLog", "5")
+    .addDefault("suoritusrekisteri.cache.redis.cacheItemLockMaxDurationSeconds", "6")
     .addDefault("suoritusrekisteri.cache.redis.port", s"${rPort}")
   )(system)
 

--- a/src/test/scala/fi/vm/sade/hakurekisteri/integration/valintatulos/ValintaTulosActorWithRedisSpec.scala
+++ b/src/test/scala/fi/vm/sade/hakurekisteri/integration/valintatulos/ValintaTulosActorWithRedisSpec.scala
@@ -34,6 +34,7 @@ class ValintaTulosActorWithRedisSpec extends ScalatraFunSuite with FutureWaiting
     .addDefault("suoritusrekisteri.cache.redis.numberOfWaitersToLog", "5")
     .addDefault("suoritusrekisteri.cache.redis.cacheItemLockMaxDurationSeconds", "6")
     .addDefault("suoritusrekisteri.cache.redis.cacheHandlingThreadPoolSize", "3")
+    .addDefault("suoritusrekisteri.cache.redis.slowRedisRequestThresholdMillis", "0")
     .addDefault("suoritusrekisteri.cache.redis.port", s"${rPort}")
   )(system)
 

--- a/src/test/scala/fi/vm/sade/hakurekisteri/integration/valintatulos/ValintaTulosActorWithRedisSpec.scala
+++ b/src/test/scala/fi/vm/sade/hakurekisteri/integration/valintatulos/ValintaTulosActorWithRedisSpec.scala
@@ -33,6 +33,7 @@ class ValintaTulosActorWithRedisSpec extends ScalatraFunSuite with FutureWaiting
     .addDefault("suoritusrekisteri.cache.redis.host", "localhost")
     .addDefault("suoritusrekisteri.cache.redis.numberOfWaitersToLog", "5")
     .addDefault("suoritusrekisteri.cache.redis.cacheItemLockMaxDurationSeconds", "6")
+    .addDefault("suoritusrekisteri.cache.redis.cacheHandlingThreadPoolSize", "3")
     .addDefault("suoritusrekisteri.cache.redis.port", s"${rPort}")
   )(system)
 

--- a/src/test/scala/fi/vm/sade/hakurekisteri/integration/valintatulos/ValintaTulosActorWithRedisSpec.scala
+++ b/src/test/scala/fi/vm/sade/hakurekisteri/integration/valintatulos/ValintaTulosActorWithRedisSpec.scala
@@ -74,7 +74,7 @@ class ValintaTulosActorWithRedisSpec extends ScalatraFunSuite with FutureWaiting
           classOf[ValintaTulosActor], "sijoittelu-tulos").get("1.2.246.562.29.90697286251"), 10.seconds)
         cached.valintatila("1.2.246.562.11.00000000576", "1.2.246.562.20.25463238029").get.toString should be (Valintatila.KESKEN.toString)
 
-        verify(endPoint).request(forUrl("http://localhost/valinta-tulos-service/haku/1.2.246.562.29.90697286251"))
+        verify(endPoint, times(1)).request(forUrl("http://localhost/valinta-tulos-service/haku/1.2.246.562.29.90697286251"))
       }
     )
   }
@@ -131,7 +131,7 @@ class ValintaTulosActorWithRedisSpec extends ScalatraFunSuite with FutureWaiting
           classOf[ValintaTulosActor], "sijoittelu-tulos").get("1.2.246.562.29.90697286253"), 10.seconds)
         cached.valintatila("1.2.246.562.11.00000000576", "1.2.246.562.20.25463238029").get.toString should be (Valintatila.KESKEN.toString)
 
-        verify(endPoint).request(forUrl("http://localhost/valinta-tulos-service/haku/1.2.246.562.29.90697286253"))
+        verify(endPoint, times(1)).request(forUrl("http://localhost/valinta-tulos-service/haku/1.2.246.562.29.90697286253"))
       }
     )
   }

--- a/src/test/scala/fi/vm/sade/hakurekisteri/integration/valintatulos/ValintaTulosActorWithRedisSpec.scala
+++ b/src/test/scala/fi/vm/sade/hakurekisteri/integration/valintatulos/ValintaTulosActorWithRedisSpec.scala
@@ -32,7 +32,6 @@ class ValintaTulosActorWithRedisSpec extends ScalatraFunSuite with FutureWaiting
     .addDefault("suoritusrekisteri.cache.redis.enabled", "true")
     .addDefault("suoritusrekisteri.cache.redis.host", "localhost")
     .addDefault("suoritusrekisteri.cache.redis.numberOfWaitersToLog", "5")
-    .addDefault("suoritusrekisteri.cache.redis.cacheItemLockMaxDurationSeconds", "6")
     .addDefault("suoritusrekisteri.cache.redis.cacheHandlingThreadPoolSize", "3")
     .addDefault("suoritusrekisteri.cache.redis.slowRedisRequestThresholdMillis", "0")
     .addDefault("suoritusrekisteri.cache.redis.port", s"${rPort}")

--- a/src/test/scala/fi/vm/sade/hakurekisteri/integration/valintatulos/ValintaTulosActorWithRedisSpec.scala
+++ b/src/test/scala/fi/vm/sade/hakurekisteri/integration/valintatulos/ValintaTulosActorWithRedisSpec.scala
@@ -34,6 +34,7 @@ class ValintaTulosActorWithRedisSpec extends ScalatraFunSuite with FutureWaiting
   def cacheFactory(implicit system:ActorSystem) = CacheFactory.apply(new OphProperties()
     .addDefault("suoritusrekisteri.cache.redis.enabled", "true")
     .addDefault("suoritusrekisteri.cache.redis.host", "localhost")
+    .addDefault("suoritusrekisteri.cache.redis.numberOfWaitersToLog", "5")
     .addDefault("suoritusrekisteri.cache.redis.port", s"${rPort}")
   )(system)
 


### PR DESCRIPTION
Suoritusrekisterin cache-tiedon hallinnassa ei ole ollut rinnakkaisuuden hallintaa sen suhteen, kuka pääsee päivittämään cachea. Niinpä tietyn tiedon vanhennuttua sitä ollaan saatettua kysyä erittäin monen kysyvän threadin pyynnöstä taustajärjestelmästä (ks. esim Jira-tiketiltä https://jira.oph.ware.fi/jira/browse/BUG-1645 ).

Alkuperäisessä tiketissä puhutaan tarjonnasta, mutta samanlaista toimintaa on näkynyt esimerkiksi koodiston suhteen.

Korjauksessa pyritään pitämään kirjaa siitä, ketkä kaikki ovat pyytäneet jotakin tietoa cachesta, ja mikäli tietoa ei valmiiksi löydy cachesta, on tarkoitus, että vain yksi sitä kysyvistä säikeistä tekee tarvittavan pyynnön taustajärjestelmään ja palauttaa sitten tiedon kaikille muille.

Lisäksi olen yrittänyt tehdä thread poolien käyttöä eksplisiittisemmäksi ja vähentää blockausta actoreissa.

Redis-cachen käytössä on myös tätä myötä sellainen toiminnallinen muutos, että joka kerta ei tarkisteta, onko arvo cachessa, ennen kuin sitä lähdetään hakemaan.