### PR TITLE
BUG-1771 : ylimääräiset Koski-arvosanojen myöntöpäivämäärät pois

### DIFF
--- a/src/main/scala/fi/vm/sade/hakurekisteri/integration/koski/KoskiArvosanaTrigger.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/integration/koski/KoskiArvosanaTrigger.scala
@@ -17,7 +17,6 @@ import org.joda.time.{DateTime, LocalDate, LocalDateTime}
 import org.json4s.DefaultFormats
 import org.slf4j.LoggerFactory
 
-import scala.collection.immutable
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
@@ -289,12 +288,12 @@ object KoskiArvosanaTrigger {
                      lisatieto: Option[String],
                      valinnainen: Boolean,
                      jarjestys: Option[Int] = None,
-                     koskiArviointiPäivä: LocalDate): Arvosana = {
+                     koskiArviointiPäiväJosSuorituksenValmistumisenJälkeen: Option[LocalDate]): Arvosana = {
     Arvosana(suoritus = null,
       arvio = arvo,
       aine, lisatieto,
       valinnainen,
-      myonnetty = Some(koskiArviointiPäivä),
+      myonnetty = koskiArviointiPäiväJosSuorituksenValmistumisenJälkeen,
       source = personOid,
       Map(),
       jarjestys = jarjestys)

--- a/src/test/resources/fi/vm/sade/hakurekisteri/integration/koski/henkilo_without_arviointipvm_from_koski.json
+++ b/src/test/resources/fi/vm/sade/hakurekisteri/integration/koski/henkilo_without_arviointipvm_from_koski.json
@@ -1,0 +1,357 @@
+{
+  "henkilö" : {
+    "oid" : "1.2.246.562.24.89890561214",
+    "hetu" : "040698-931R",
+    "syntymäaika" : "1998-06-04",
+    "etunimet" : "Frank Balthazar",
+    "kutsumanimi" : "Frank",
+    "sukunimi": "Tester",
+    "äidinkieli" : {
+      "koodiarvo" : "FI",
+      "nimi" : {
+        "fi" : "suomi",
+        "sv" : "finska",
+        "en" : "Finnish"
+      },
+      "lyhytNimi" : {
+        "fi" : "suomi",
+        "sv" : "finska",
+        "en" : "Finnish"
+      },
+      "koodistoUri" : "kieli",
+      "koodistoVersio" : 1
+    },
+    "kansalaisuus" : [ {
+      "koodiarvo" : "246",
+      "nimi" : {
+        "fi" : "Suomi",
+        "sv" : "Finland",
+        "en" : "Finland"
+      },
+      "lyhytNimi" : {
+        "fi" : "FI",
+        "sv" : "FI",
+        "en" : "FI"
+      },
+      "koodistoUri" : "maatjavaltiot2",
+      "koodistoVersio" : 1
+    } ],
+    "turvakielto" : false
+  },
+  "opiskeluoikeudet" : [ {
+    "oid" : "1.2.246.562.15.62445294085",
+    "versionumero" : 7,
+    "aikaleima" : "2018-05-29T15:44:56.906767",
+    "lähdejärjestelmänId" : {
+      "id" : "528",
+      "lähdejärjestelmä" : {
+        "koodiarvo" : "primus",
+        "nimi" : {
+          "fi" : "primus"
+        },
+        "koodistoUri" : "lahdejarjestelma",
+        "koodistoVersio" : 1
+      }
+    },
+    "oppilaitos" : {
+      "oid" : "1.2.246.562.10.96894821105",
+      "oppilaitosnumero" : {
+        "koodiarvo" : "01693",
+        "nimi" : {
+          "fi" : "Valkealan kristillinen kansanopisto"
+        },
+        "lyhytNimi" : {
+          "fi" : "Valkealan kristillinen kansanopisto"
+        },
+        "koodistoUri" : "oppilaitosnumero",
+        "koodistoVersio" : 1
+      },
+      "nimi" : {
+        "fi" : "Valkealan kristillinen kansanopisto"
+      },
+      "kotipaikka" : {
+        "koodiarvo" : "286",
+        "nimi" : {
+          "fi" : "Kouvola",
+          "sv" : "Kouvola"
+        },
+        "koodistoUri" : "kunta",
+        "koodistoVersio" : 2
+      }
+    },
+    "koulutustoimija" : {
+      "oid" : "1.2.246.562.10.82454214766",
+      "nimi" : {
+        "fi" : "Valkealan Kristillisen Kansanopiston kannatusyhdistys r.y."
+      },
+      "yTunnus" : "0163408-0",
+      "kotipaikka" : {
+        "koodiarvo" : "286",
+        "nimi" : {
+          "fi" : "Kouvola",
+          "sv" : "Kouvola"
+        },
+        "koodistoUri" : "kunta",
+        "koodistoVersio" : 2
+      }
+    },
+    "päättymispäivä" : "2018-06-01",
+    "tila" : {
+      "opiskeluoikeusjaksot" : [ {
+        "alku" : "2017-08-21",
+        "tila" : {
+          "koodiarvo" : "lasna",
+          "nimi" : {
+            "fi" : "Läsnä",
+            "sv" : "Närvarande"
+          },
+          "koodistoUri" : "koskiopiskeluoikeudentila",
+          "koodistoVersio" : 1
+        }
+      }, {
+        "alku" : "2018-06-01",
+        "tila" : {
+          "koodiarvo" : "valmistunut",
+          "nimi" : {
+            "fi" : "Valmistunut",
+            "sv" : "Utexaminerad"
+          },
+          "koodistoUri" : "koskiopiskeluoikeudentila",
+          "koodistoVersio" : 1
+        }
+      } ]
+    },
+    "lisätiedot" : {
+      "vuosiluokkiinSitoutumatonOpetus" : false
+    },
+    "suoritukset" : [ {
+      "koulutusmoduuli" : {
+        "perusteenDiaarinumero" : "OPH-1280-2017",
+        "tunniste" : {
+          "koodiarvo" : "201101",
+          "nimi" : {
+            "fi" : "Perusopetus",
+            "sv" : "Grundläggande utbildning",
+            "en" : "Basic education"
+          },
+          "koodistoUri" : "koulutus",
+          "koodistoVersio" : 9
+        },
+        "koulutustyyppi" : {
+          "koodiarvo" : "17",
+          "nimi" : {
+            "fi" : "Aikuisten perusopetus",
+            "sv" : "Grundläggande utbildning för vuxna",
+            "en" : "Aikuisten perusopetus"
+          },
+          "lyhytNimi" : {
+            "fi" : "Aikuisten perusopetus",
+            "sv" : "Grundläggande utbildning för vuxna",
+            "en" : "Aikuisten perusopetus"
+          },
+          "koodistoUri" : "koulutustyyppi",
+          "koodistoVersio" : 2
+        }
+      },
+      "toimipiste" : {
+        "oid" : "1.2.246.562.10.96894821105",
+        "oppilaitosnumero" : {
+          "koodiarvo" : "01693",
+          "nimi" : {
+            "fi" : "Valkealan kristillinen kansanopisto"
+          },
+          "lyhytNimi" : {
+            "fi" : "Valkealan kristillinen kansanopisto"
+          },
+          "koodistoUri" : "oppilaitosnumero",
+          "koodistoVersio" : 1
+        },
+        "nimi" : {
+          "fi" : "Valkealan kristillinen kansanopisto"
+        },
+        "kotipaikka" : {
+          "koodiarvo" : "286",
+          "nimi" : {
+            "fi" : "Kouvola",
+            "sv" : "Kouvola"
+          },
+          "koodistoUri" : "kunta",
+          "koodistoVersio" : 2
+        }
+      },
+      "vahvistus" : {
+        "päivä" : "2018-06-01",
+        "paikkakunta" : {
+          "koodiarvo" : "286",
+          "nimi" : {
+            "fi" : "Kouvola",
+            "sv" : "Kouvola"
+          },
+          "koodistoUri" : "kunta",
+          "koodistoVersio" : 2
+        },
+        "myöntäjäOrganisaatio" : {
+          "oid" : "1.2.246.562.10.96894821105",
+          "oppilaitosnumero" : {
+            "koodiarvo" : "01693",
+            "nimi" : {
+              "fi" : "Valkealan kristillinen kansanopisto"
+            },
+            "lyhytNimi" : {
+              "fi" : "Valkealan kristillinen kansanopisto"
+            },
+            "koodistoUri" : "oppilaitosnumero",
+            "koodistoVersio" : 1
+          },
+          "nimi" : {
+            "fi" : "Valkealan kristillinen kansanopisto"
+          },
+          "kotipaikka" : {
+            "koodiarvo" : "286",
+            "nimi" : {
+              "fi" : "Kouvola",
+              "sv" : "Kouvola"
+            },
+            "koodistoUri" : "kunta",
+            "koodistoVersio" : 2
+          }
+        },
+        "myöntäjäHenkilöt" : [ {
+          "nimi" : "Jussi Peurala",
+          "titteli" : {
+            "fi" : "rehtori"
+          },
+          "organisaatio" : {
+            "oid" : "1.2.246.562.10.96894821105",
+            "oppilaitosnumero" : {
+              "koodiarvo" : "01693",
+              "nimi" : {
+                "fi" : "Valkealan kristillinen kansanopisto"
+              },
+              "lyhytNimi" : {
+                "fi" : "Valkealan kristillinen kansanopisto"
+              },
+              "koodistoUri" : "oppilaitosnumero",
+              "koodistoVersio" : 1
+            },
+            "nimi" : {
+              "fi" : "Valkealan kristillinen kansanopisto"
+            },
+            "kotipaikka" : {
+              "koodiarvo" : "286",
+              "nimi" : {
+                "fi" : "Kouvola",
+                "sv" : "Kouvola"
+              },
+              "koodistoUri" : "kunta",
+              "koodistoVersio" : 2
+            }
+          }
+        } ]
+      },
+      "suoritustapa" : {
+        "koodiarvo" : "koulutus",
+        "nimi" : {
+          "fi" : "Koulutus",
+          "sv" : "Utbildning"
+        },
+        "koodistoUri" : "perusopetuksensuoritustapa",
+        "koodistoVersio" : 1
+      },
+      "suorituskieli" : {
+        "koodiarvo" : "FI",
+        "nimi" : {
+          "fi" : "suomi",
+          "sv" : "finska",
+          "en" : "Finnish"
+        },
+        "lyhytNimi" : {
+          "fi" : "suomi",
+          "sv" : "finska",
+          "en" : "Finnish"
+        },
+        "koodistoUri" : "kieli",
+        "koodistoVersio" : 1
+      },
+      "osasuoritukset" : [ {
+        "koulutusmoduuli" : {
+          "tunniste" : {
+            "koodiarvo" : "BI",
+            "nimi" : {
+              "fi" : "Biologia",
+              "sv" : "Biologi"
+            },
+            "lyhytNimi" : {
+              "fi" : "Biologia",
+              "sv" : "Biologi"
+            },
+            "koodistoUri" : "koskioppiaineetyleissivistava",
+            "koodistoVersio" : 1
+          },
+          "pakollinen" : true,
+          "perusteenDiaarinumero" : "OPH-1280-2017"
+        },
+        "arviointi" : [ {
+          "arvosana" : {
+            "koodiarvo" : "6",
+            "nimi" : {
+              "fi" : "kohtalainen",
+              "sv" : "hjälplig"
+            },
+            "lyhytNimi" : {
+              "fi" : "6"
+            },
+            "koodistoUri" : "arviointiasteikkoyleissivistava",
+            "koodistoVersio" : 1
+          },
+          "hyväksytty" : true
+        } ],
+        "suorituskieli" : {
+          "koodiarvo" : "FI",
+          "nimi" : {
+            "fi" : "suomi",
+            "sv" : "finska",
+            "en" : "Finnish"
+          },
+          "lyhytNimi" : {
+            "fi" : "suomi",
+            "sv" : "finska",
+            "en" : "Finnish"
+          },
+          "koodistoUri" : "kieli",
+          "koodistoVersio" : 1
+        },
+        "tyyppi" : {
+          "koodiarvo" : "aikuistenperusopetuksenoppiaine",
+          "nimi" : {
+            "fi" : "Aikuisten perusopetuksen oppiaine"
+          },
+          "koodistoUri" : "suorituksentyyppi",
+          "koodistoVersio" : 1
+        }
+      } ],
+      "tyyppi" : {
+        "koodiarvo" : "aikuistenperusopetuksenoppimaara",
+        "nimi" : {
+          "fi" : "Aikuisten perusopetuksen oppimäärä",
+          "sv" : "Lärökurs i den grundläggande utbildningen för vuxna"
+        },
+        "koodistoUri" : "suorituksentyyppi",
+        "koodistoVersio" : 1
+      }
+    } ],
+    "tyyppi" : {
+      "koodiarvo" : "aikuistenperusopetus",
+      "nimi" : {
+        "fi" : "Aikuisten perusopetus",
+        "sv" : "Grundläggande utbildning för vuxna"
+      },
+      "lyhytNimi" : {
+        "fi" : "Aikuisten perusopetus"
+      },
+      "koodistoUri" : "opiskeluoikeudentyyppi",
+      "koodistoVersio" : 1
+    },
+    "alkamispäivä" : "2017-08-21"
+  } ]
+}

--- a/src/test/scala/fi/vm/sade/hakurekisteri/integration/koski/ArvosanaMyonnettyParserSpec.scala
+++ b/src/test/scala/fi/vm/sade/hakurekisteri/integration/koski/ArvosanaMyonnettyParserSpec.scala
@@ -2,26 +2,37 @@ package fi.vm.sade.hakurekisteri.integration.koski
 
 
 import fi.vm.sade.hakurekisteri.rest.support.HakurekisteriJsonSupport
+import org.apache.commons.io.IOUtils
 import org.joda.time.LocalDate
 import org.json4s.jackson.JsonMethods
 import org.scalatest.{FlatSpec, ShouldMatchers}
+import org.springframework.core.io.ClassPathResource
+
+import scala.collection.JavaConverters._
 
 class ArvosanaMyonnettyParserSpec extends FlatSpec with ShouldMatchers with HakurekisteriJsonSupport with JsonMethods {
-  private val jsonString: String = scala.io.Source.fromFile("src/test/resources/fi/vm/sade/hakurekisteri/integration/koski/henkilo_from_koski.json").getLines().mkString
-
   it should "parse dates for arvosanas" in {
-    val testDataJson = parse(jsonString)
-    val koskiHenkiloContainer = testDataJson.extract[KoskiHenkiloContainer]
-
-    val osaSuoritukset: Seq[KoskiOsasuoritus] = for {
-      opiskeluoikeus <- koskiHenkiloContainer.opiskeluoikeudet
-      suoritus <- opiskeluoikeus.suoritukset
-      osasuoritus <- suoritus.osasuoritukset
-    } yield osasuoritus
+    val osaSuoritukset: Seq[KoskiOsasuoritus] = readOsasuoritukset("henkilo_from_koski.json")
 
     val biologia = osaSuoritukset.find(_.koulutusmoduuli.tunniste.exists(_.koodiarvo == "BI"))
     biologia shouldBe defined
     val determinedDate = ArvosanaMyonnettyParser.findArviointipäivä(biologia.get, "personOid", "aine", new LocalDate(1970, 1, 1))
     determinedDate should be(new LocalDate(2018, 12, 31))
+  }
+
+  private def readOsasuoritukset(fileNameInSamePackage: String) = {
+    val jsonString: String = readFileFromClasspath(fileNameInSamePackage)
+    val koskiHenkiloContainer = parse(jsonString).extract[KoskiHenkiloContainer]
+
+    for {
+      opiskeluoikeus <- koskiHenkiloContainer.opiskeluoikeudet
+      suoritus <- opiskeluoikeus.suoritukset
+      osasuoritus <- suoritus.osasuoritukset
+    } yield osasuoritus
+  }
+
+  private def readFileFromClasspath(fileNameInSamePackage: String) = {
+    val classPathResource = new ClassPathResource(fileNameInSamePackage, getClass)
+    IOUtils.readLines(classPathResource.getInputStream, "UTF-8").asScala.mkString
   }
 }

--- a/src/test/scala/fi/vm/sade/hakurekisteri/integration/koski/ArvosanaMyonnettyParserSpec.scala
+++ b/src/test/scala/fi/vm/sade/hakurekisteri/integration/koski/ArvosanaMyonnettyParserSpec.scala
@@ -17,7 +17,32 @@ class ArvosanaMyonnettyParserSpec extends FlatSpec with ShouldMatchers with Haku
     val biologia = osaSuoritukset.find(_.koulutusmoduuli.tunniste.exists(_.koodiarvo == "BI"))
     biologia shouldBe defined
     val determinedDate = ArvosanaMyonnettyParser.findArviointipäivä(biologia.get, "personOid", "aine", new LocalDate(1970, 1, 1))
-    determinedDate should be(new LocalDate(2018, 12, 31))
+    determinedDate should be(Some(new LocalDate(2018, 12, 31)))
+  }
+
+  it should "only take arvosana specific myonto dates when they are after suoritus valmistuminen date" in {
+    val osaSuoritukset: Seq[KoskiOsasuoritus] = readOsasuoritukset("henkilo_from_koski.json")
+
+    val suorituksenValmistumisPvm: LocalDate = new LocalDate(2018, 6, 2)
+
+    val biologia = osaSuoritukset.find(_.koulutusmoduuli.tunniste.exists(_.koodiarvo == "BI"))
+    biologia shouldBe defined
+    val biologiaDate = ArvosanaMyonnettyParser.findArviointipäivä(biologia.get, "personOid", "aine", suorituksenValmistumisPvm)
+    biologiaDate should be(Some(new LocalDate(2018, 12, 31)))
+
+    val terveystieto = osaSuoritukset.find(_.koulutusmoduuli.tunniste.exists(_.koodiarvo == "TE"))
+    terveystieto shouldBe defined
+    val terveystietoDate = ArvosanaMyonnettyParser.findArviointipäivä(terveystieto.get, "personOid", "terveystieto", suorituksenValmistumisPvm)
+    terveystietoDate should be(None)
+  }
+
+  it should "not store arvosana specific myonto dates when they are null in Koski" in {
+    val osaSuoritukset: Seq[KoskiOsasuoritus] = readOsasuoritukset("henkilo_without_arviointipvm_from_koski.json")
+
+    val ensimmainenVierasKieli = osaSuoritukset.find(_.koulutusmoduuli.tunniste.exists(_.koodiarvo == "BI"))
+    ensimmainenVierasKieli shouldBe defined
+    val vieraanKielenMyontoPvm = ArvosanaMyonnettyParser.findArviointipäivä(ensimmainenVierasKieli.get, "personOid", "bilsa", new LocalDate(2018, 6, 19))
+    vieraanKielenMyontoPvm should be(None)
   }
 
   private def readOsasuoritukset(fileNameInSamePackage: String) = {


### PR DESCRIPTION
Tallennetaan arvosanalle myöntöpäivämäärä vain tämän ollessa myöhemmin kuin suorituksen valmistumispäivämäärä. Tällöin korotukset näkyvät oikein ja tulevat skipatuiksi laskennassa sikäli kun ne on myönnetty laskennan alun jälkeen.