### PR TITLE
BUG-1758 : Use new more performant API

### DIFF
--- a/src/main/resources/suoritusrekisteri-oph.properties
+++ b/src/main/resources/suoritusrekisteri-oph.properties
@@ -18,7 +18,7 @@ organisaatio-service.soap=/organisaatio-service/services/organisaatioService
 ohjausparametrit-service.all=/ohjausparametrit-service/api/v1/rest/parametri/ALL
 ohjausparametrit-service.parametri=/ohjausparametrit-service/api/v1/rest/parametri/$1
 valinta-tulos-service.ensikertalaisuus=/valinta-tulos-service/ensikertalaisuus?koulutuksenAlkamiskausi=$1
-valinta-tulos-service.lukuvuosimaksu=/valinta-tulos-service/lukuvuosimaksu/read/$1
+valinta-tulos-service.lukuvuosimaksu.bulk=/valinta-tulos-service/lukuvuosimaksu/read
 valinta-tulos-service.vastaanottotiedot=/valinta-tulos-service/ensikertalaisuus/$1/historia
 valinta-tulos-service.hakemus=/valinta-tulos-service/haku/$1/hakemus/$2
 valinta-tulos-service.haku=/valinta-tulos-service/haku/$1

--- a/src/main/scala/fi/vm/sade/hakurekisteri/integration/valintarekisteri/ValintarekisteriActor.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/integration/valintarekisteri/ValintarekisteriActor.scala
@@ -21,14 +21,15 @@ class ValintarekisteriActor(restClient: VirkailijaRestClient, config: Config) ex
   private val ok = 200
 
   override def receive: Receive = {
-    case LukuvuosimaksuQuery(hakukohdeOid, auditSession) =>
-      fetchLukuvuosimaksut(hakukohdeOid, auditSession) pipeTo sender
+    case LukuvuosimaksuQuery(hakukohdeOids, auditSession) =>
+      fetchLukuvuosimaksut(hakukohdeOids, auditSession) pipeTo sender
     case ValintarekisteriQuery(personOidsWithAliases, koulutuksenAlkamiskausi) =>
       val henkiloOids = personOidsWithAliases.henkiloOids // Valintarekisteri already returns data for aliases
       fetchEnsimmainenVastaanotto(henkiloOids, koulutuksenAlkamiskausi) pipeTo sender
   }
-  def fetchLukuvuosimaksut(hakukohdeOid: String, auditSession: AuditSessionRequest): Future[Seq[Lukuvuosimaksu]] = {
-    restClient.postObject[Map[String, AuditSessionRequest], Seq[Lukuvuosimaksu]]("valinta-tulos-service.lukuvuosimaksu", hakukohdeOid)(ok, Map("auditSession" -> auditSession))
+  def fetchLukuvuosimaksut(hakukohdeOids: Set[String], auditSession: AuditSessionRequest): Future[Seq[Lukuvuosimaksu]] = {
+    val request = Map("hakukohdeOids" -> hakukohdeOids, "auditSession" -> auditSession)
+    restClient.postObject[AnyRef, Seq[Lukuvuosimaksu]]("valinta-tulos-service.lukuvuosimaksu.bulk")(ok, request)
   }
   def fetchEnsimmainenVastaanotto(henkiloOids: Set[String], koulutuksenAlkamiskausi: String): Future[Seq[EnsimmainenVastaanotto]] = {
     restClient.postObject[Set[String], Seq[EnsimmainenVastaanotto]]("valinta-tulos-service.ensikertalaisuus", koulutuksenAlkamiskausi)(ok, henkiloOids)
@@ -46,7 +47,7 @@ object Maksuntila extends Enumeration {
 
 case class Lukuvuosimaksu(personOid: String, hakukohdeOid: String, maksuntila: Maksuntila, muokkaaja: String, luotu: Date)
 
-case class LukuvuosimaksuQuery(hakukohdeOid: String, auditSession: AuditSessionRequest)
+case class LukuvuosimaksuQuery(hakukohdeOids: Set[String], auditSession: AuditSessionRequest)
 
 case class ValintarekisteriQuery(personOidsWithAliases: PersonOidsWithAliases, koulutuksenAlkamiskausi: String)
 

--- a/src/main/scala/fi/vm/sade/hakurekisteri/web/kkhakija/KkHakijaService.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/web/kkhakija/KkHakijaService.scala
@@ -244,11 +244,7 @@ class KkHakijaService(hakemusService: IHakemusService,
     .mapTo[SijoitteluTulos]
 
   private def getLukuvuosimaksut(hakukohdeOids: Set[String], auditSession: AuditSessionRequest): Future[Seq[Lukuvuosimaksu]] = {
-    val querys = hakukohdeOids.toSeq.map(LukuvuosimaksuQuery(_, auditSession))
-
-    val maksutByHakukohde: Seq[Future[Seq[Lukuvuosimaksu]]] = querys.map(q => (valintaRekisteri ? q).mapTo[Seq[Lukuvuosimaksu]])
-    val sequenced: Future[Seq[Seq[Lukuvuosimaksu]]] = Future.sequence(maksutByHakukohde)
-    sequenced.map[Seq[Lukuvuosimaksu]](_.flatten)
+    (valintaRekisteri ? LukuvuosimaksuQuery(hakukohdeOids, auditSession)).mapTo[Seq[Lukuvuosimaksu]]
   }
 
   private def getHakemukset(haku: Haku, hakemus: HakijaHakemus, lukuvuosimaksutByHakukohdeOid: Map[String, List[Lukuvuosimaksu]], q: KkHakijaQuery,

--- a/src/test/resources/suoritusrekisteri-oph.properties
+++ b/src/test/resources/suoritusrekisteri-oph.properties
@@ -19,7 +19,7 @@ ohjausparametrit-service.parametri=/ohjausparametrit-service/api/v1/rest/paramet
 oppijanumerorekisteri-service.duplicatesByPersonOids=/oppijanumerorekisteri-service/s2s/duplicateHenkilos
 oppijanumerorekisteri-service.henkilotByOids=/oppijanumerorekisteri-service/henkilo/henkilotByHenkiloOidList
 valinta-tulos-service.ensikertalaisuus=/valinta-tulos-service/ensikertalaisuus?koulutuksenAlkamiskausi=$1
-valinta-tulos-service.lukuvuosimaksu=/valinta-tulos-service/lukuvuosimaksu/read/$1
+valinta-tulos-service.lukuvuosimaksu.bulk=/valinta-tulos-service/lukuvuosimaksu/read
 valinta-tulos-service.vastaanottotiedot=/valinta-tulos-service/ensikertalaisuus/$1/historia
 valinta-tulos-service.hakemus=/valinta-tulos-service/haku/$1/hakemus/$2
 valinta-tulos-service.haku=/valinta-tulos-service/haku/$1

--- a/src/test/scala/fi/vm/sade/hakurekisteri/web/kkhakija/KkHakijaServiceSpec.scala
+++ b/src/test/scala/fi/vm/sade/hakurekisteri/web/kkhakija/KkHakijaServiceSpec.scala
@@ -378,11 +378,15 @@ class KkHakijaServiceSpec extends ScalatraFunSuite with HakeneetSupport with Moc
   }
 
   class MockedValintarekisteriActor extends Actor {
+    private val mockedMaksus: Seq[Lukuvuosimaksu] = List(
+      Lukuvuosimaksu(personOidWithLukuvuosimaksu, paymentRequiredHakukohdeWithMaksettu, Maksuntila.maksettu, "muokkaaja", new Date()),
+      Lukuvuosimaksu(personOidWithLukuvuosimaksu, noPaymentRequiredHakukohdeButMaksettu, Maksuntila.maksettu, "muokkaaja2", new LocalDate().minusDays(1).toDate)
+    )
+
     override def receive: Actor.Receive = {
-      case LukuvuosimaksuQuery(hakukohdeOid, _) if hakukohdeOid == paymentRequiredHakukohdeWithMaksettu =>
-        sender ! Seq(Lukuvuosimaksu(personOidWithLukuvuosimaksu, paymentRequiredHakukohdeWithMaksettu, Maksuntila.maksettu, "muokkaaja", new Date()))
-      case LukuvuosimaksuQuery(hakukohdeOid, _) if hakukohdeOid == noPaymentRequiredHakukohdeButMaksettu =>
-        sender ! Seq(Lukuvuosimaksu(personOidWithLukuvuosimaksu, noPaymentRequiredHakukohdeButMaksettu, Maksuntila.maksettu, "muokkaaja2", new LocalDate().minusDays(1).toDate))
+      case LukuvuosimaksuQuery(hakukohdeOids, _) if hakukohdeOids.contains(paymentRequiredHakukohdeWithMaksettu) ||
+        hakukohdeOids.contains(noPaymentRequiredHakukohdeButMaksettu) =>
+        sender ! mockedMaksus
       case _ =>
         sender ! Nil
     }


### PR DESCRIPTION
This way we can get all lukuvuosimaksu data for a single
hakukohde with a single fast query to valinta-tulos-service.
Previously, if we had e.g. 5000 candidates applying in this
hakukohde and a 1000 other different hakukohdes in their
applications, 1000 requests would be required.

Here, taking to use the new API in valinta-tulos-service : https://github.com/Opetushallitus/valinta-tulos-service/pull/88 