### PR TITLE
BUG-1733  muuttuneen luokan redis-cachen tyhjennys

### DIFF
--- a/src/main/scala/fi/vm/sade/hakurekisteri/integration/cache/CacheFactory.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/integration/cache/CacheFactory.scala
@@ -98,7 +98,7 @@ object CacheFactory {
 
       private def init(): Unit = {
         if (classOfT.getName.equals("scala.Option")) {
-          logger.error("In cache with prefix $cacheKeyPrefix, given classOfT parameter was an Option. Please use the" +
+          logger.error(s"In cache with prefix $cacheKeyPrefix, given classOfT parameter was an Option. Please use the" +
             " inner type instead, e.g. classOf[A] instead of classOf[Option[A]]. Otherwise changes to the serializable" +
             " class will not be detected and deserialization may break.")
         }
@@ -106,7 +106,7 @@ object CacheFactory {
         val runTimeTypeClass = manifest[T].runtimeClass
         if (!runTimeTypeClass.equals(classOfT)) {
           logger.warn(s"In cache with prefix $cacheKeyPrefix, class of type parameter T (${runTimeTypeClass.getName})" +
-            s" was not the same as given classOfT (${classOfT.getClass})." +
+            s" was not the same as given classOfT (${classOfT.getName})." +
             " This is not a problem if the former is a wrapper for the latter, such as an Option.")
         }
 
@@ -142,7 +142,7 @@ object CacheFactory {
           logger.info("Finished scanning and deleting.")
           setVersion(newVersion)
         } else {
-          logger.info(s"Serial version UID has not changed, is still $newVersion.")
+          logger.info(s"Serial version UID has not changed in cache with prefix $cacheKeyPrefix., is still $newVersion.")
           Future.successful(true)
         }
       }

--- a/src/main/scala/fi/vm/sade/hakurekisteri/integration/cache/CacheFactory.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/integration/cache/CacheFactory.scala
@@ -104,10 +104,9 @@ object CacheFactory {
         }
 
         val runTimeTypeClass = manifest[T].runtimeClass
-        if (!runTimeTypeClass.equals(classOfT)) {
+        if (!runTimeTypeClass.equals(classOfT) && !runTimeTypeClass.getName.equals("scala.Option")) {
           logger.warn(s"In cache with prefix $cacheKeyPrefix, class of type parameter T (${runTimeTypeClass.getName})" +
-            s" was not the same as given classOfT (${classOfT.getName})." +
-            " This is not a problem if the former is a wrapper for the latter, such as an Option.")
+            s" was not the same as given classOfT (${classOfT.getName}).")
         }
 
         val f: Future[Boolean] = getVersion.flatMap {

--- a/src/main/scala/fi/vm/sade/hakurekisteri/integration/cache/CacheFactory.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/integration/cache/CacheFactory.scala
@@ -84,7 +84,14 @@ object CacheFactory {
       private val versionPrefixKey = s"${cacheKeyPrefix}:version"
       private val newVersion: Long = {
         val streamClass = java.io.ObjectStreamClass.lookup(classOfT)
-        streamClass.getSerialVersionUID
+        try {
+          streamClass.getSerialVersionUID
+        } catch {
+          case e: NullPointerException =>
+            val msg = s"Class ${classOfT.getName} is not serializable - getSerialVersionUID resulted in NullPointerException"
+            logger.error(msg)
+            throw new RedisCacheInitializationException(msg)
+        }
       }
 
       init()

--- a/src/main/scala/fi/vm/sade/hakurekisteri/integration/cache/monadCache.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/integration/cache/monadCache.scala
@@ -21,6 +21,8 @@ trait MonadCache[F[_], K, T] {
 
   def get(key: K, loader: K => F[Option[T]]): F[Option[T]]
 
+  def getVersion: Future[Option[Long]]
+
   def toOption(value: F[T]): F[Option[T]]
 
   protected def k(key: K, prefix:String) = s"${prefix}:${key}"
@@ -112,6 +114,8 @@ class InMemoryFutureCache[K, T](val expirationDurationMillis: Long = 60.minutes.
   private def createSynchonizedList: java.util.List[Promise[Option[T]]] = {
     Collections.synchronizedList(new java.util.ArrayList[Promise[Option[T]]]())
   }
+
+  override def getVersion: Future[Option[Long]] = Future.successful(Some(0l))
 }
 
 case class Cacheable[F[_], T](inserted: Long = Platform.currentTime, accessed: Long = Platform.currentTime, f: F[T])

--- a/src/main/scala/fi/vm/sade/hakurekisteri/integration/koodisto/KoodistoActor.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/integration/koodisto/KoodistoActor.scala
@@ -27,7 +27,7 @@ class KoodistoActor(restClient: VirkailijaRestClient, config: Config, cacheFacto
   implicit val ec: ExecutionContext =  context.dispatcher
 
   private val koodiCache = cacheFactory.getInstance[String, Option[Koodi]](config.integrations.koodistoCacheHours.hours.toMillis, this.getClass, classOf[Koodi], "koodi")
-  private val relaatioCache = cacheFactory.getInstance[GetRinnasteinenKoodiArvoQuery, String](config.integrations.koodistoCacheHours.hours.toMillis, this.getClass, classOf[GetRinnasteinenKoodiArvoQuery], "relaatio")
+  private val relaatioCache = cacheFactory.getInstance[GetRinnasteinenKoodiArvoQuery, String](config.integrations.koodistoCacheHours.hours.toMillis, this.getClass, classOf[String], "relaatio")
   private val koodiArvotCache = cacheFactory.getInstance[String, KoodistoKoodiArvot](config.integrations.koodistoCacheHours.hours.toMillis, this.getClass, classOf[KoodistoKoodiArvot],"koodi-arvo")
   val maxRetries = config.integrations.koodistoConfig.httpClientMaxRetries
 

--- a/src/main/scala/fi/vm/sade/hakurekisteri/integration/koodisto/KoodistoActor.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/integration/koodisto/KoodistoActor.scala
@@ -26,9 +26,9 @@ class KoodistoActor(restClient: VirkailijaRestClient, config: Config, cacheFacto
 
   implicit val ec: ExecutionContext =  context.dispatcher
 
-  private val koodiCache = cacheFactory.getInstance[String, Option[Koodi]](config.integrations.koodistoCacheHours.hours.toMillis, getClass, "koodi")
-  private val relaatioCache = cacheFactory.getInstance[GetRinnasteinenKoodiArvoQuery, String](config.integrations.koodistoCacheHours.hours.toMillis, getClass, "relaatio")
-  private val koodiArvotCache = cacheFactory.getInstance[String, KoodistoKoodiArvot](config.integrations.koodistoCacheHours.hours.toMillis, getClass, "koodi-arvo")
+  private val koodiCache = cacheFactory.getInstance[String, Option[Koodi]](config.integrations.koodistoCacheHours.hours.toMillis, this.getClass, classOf[Koodi], "koodi")
+  private val relaatioCache = cacheFactory.getInstance[GetRinnasteinenKoodiArvoQuery, String](config.integrations.koodistoCacheHours.hours.toMillis, this.getClass, classOf[GetRinnasteinenKoodiArvoQuery], "relaatio")
+  private val koodiArvotCache = cacheFactory.getInstance[String, KoodistoKoodiArvot](config.integrations.koodistoCacheHours.hours.toMillis, this.getClass, classOf[KoodistoKoodiArvot],"koodi-arvo")
   val maxRetries = config.integrations.koodistoConfig.httpClientMaxRetries
 
   override def receive: Receive = {

--- a/src/main/scala/fi/vm/sade/hakurekisteri/integration/organisaatio/OrganisaatioActor.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/integration/organisaatio/OrganisaatioActor.scala
@@ -36,8 +36,8 @@ class HttpOrganisaatioActor(organisaatioClient: VirkailijaRestClient,
 
   log.info(s"timeToLive: $timeToLive, reloadInterval: $reloadInterval")
 
-  private val cache = cacheFactory.getInstance[String, Organisaatio](timeToLive.toMillis, getClass, "organisaatio")
-  private val childOidCache = cacheFactory.getInstance[String, ChildOids](timeToLive.toMillis, getClass, "child-oids")
+  private val cache = cacheFactory.getInstance[String, Organisaatio](timeToLive.toMillis, this.getClass, classOf[Organisaatio], "organisaatio")
+  private val childOidCache = cacheFactory.getInstance[String, ChildOids](timeToLive.toMillis, this.getClass, classOf[ChildOids], "child-oids")
   private var oppilaitoskoodiIndex: Map[String, String] = Map()
 
   private def saveOrganisaatiot(s: Seq[Organisaatio]): Future[_] = {

--- a/src/main/scala/fi/vm/sade/hakurekisteri/integration/tarjonta/TarjontaActor.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/integration/tarjonta/TarjontaActor.scala
@@ -78,9 +78,9 @@ case class KoulutusNotFoundException(message: String) extends TarjontaException(
 case class KomoNotFoundException(message: String) extends TarjontaException(message)
 
 class TarjontaActor(restClient: VirkailijaRestClient, config: Config, cacheFactory: CacheFactory) extends Actor with ActorLogging {
-  private val koulutusCache = cacheFactory.getInstance[String, HakukohteenKoulutukset](config.integrations.tarjontaCacheHours.hours.toMillis, getClass, "koulutus")
-  private val komoCache = cacheFactory.getInstance[String, KomoResponse](config.integrations.tarjontaCacheHours.hours.toMillis, getClass, "komo")
-  private val hakukohdeCache = cacheFactory.getInstance[String, Option[Hakukohde]](config.integrations.tarjontaCacheHours.hours.toMillis, getClass, "hakukohde")
+  private val koulutusCache = cacheFactory.getInstance[String, HakukohteenKoulutukset](config.integrations.tarjontaCacheHours.hours.toMillis, this.getClass, classOf[HakukohteenKoulutukset], "koulutus")
+  private val komoCache = cacheFactory.getInstance[String, KomoResponse](config.integrations.tarjontaCacheHours.hours.toMillis, this.getClass, classOf[KomoResponse], "komo")
+  private val hakukohdeCache = cacheFactory.getInstance[String, Option[Hakukohde]](config.integrations.tarjontaCacheHours.hours.toMillis, this.getClass, classOf[Hakukohde], "hakukohde")
 
   val maxRetries = config.integrations.tarjontaConfig.httpClientMaxRetries
   implicit val ec: ExecutionContext = context.dispatcher

--- a/src/main/scala/fi/vm/sade/hakurekisteri/integration/valintatulos/SijoitteluTulos.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/integration/valintatulos/SijoitteluTulos.scala
@@ -71,7 +71,7 @@ case class ValintaTulosHakutoive(hakukohdeOid: String,
 
 case class ValintaTulos(hakemusOid: String, hakutoiveet: Seq[ValintaTulosHakutoive])
 
-trait SijoitteluTulos {
+trait SijoitteluTulos extends Serializable {
   def pisteet(hakemus: String, kohde: String): Option[BigDecimal]
   def valintatila(hakemus: String, kohde: String): Option[Valintatila]
   def vastaanottotila(hakemus: String, kohde: String): Option[Vastaanottotila]

--- a/src/main/scala/fi/vm/sade/hakurekisteri/integration/valintatulos/ValintaTulosActor.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/integration/valintatulos/ValintaTulosActor.scala
@@ -28,7 +28,7 @@ class ValintaTulosActor(client: VirkailijaRestClient,
   private val maxRetries: Int = config.integrations.valintaTulosConfig.httpClientMaxRetries
   private val refetch: FiniteDuration = refetchTime.map(_.milliseconds).getOrElse((config.integrations.valintatulosCacheHours / 2).hours)
   private val retry: FiniteDuration = retryTime.map(_.milliseconds).getOrElse(60.seconds)
-  private val cache = cacheFactory.getInstance[String, SijoitteluTulos](cacheTime.getOrElse(config.integrations.valintatulosCacheHours.hours.toMillis), this.getClass, classOf[ValintaTulosToSijoitteluTulos], "sijoittelu-tulos")
+  private val cache = cacheFactory.getInstance[String, SijoitteluTulos](cacheTime.getOrElse(config.integrations.valintatulosCacheHours.hours.toMillis), this.getClass, classOf[SijoitteluTulos], "sijoittelu-tulos")
   private var calling: Boolean = false
   private var initialLoadingDone = initOnStartup
   private val startTimeMillis: Long = System.currentTimeMillis()

--- a/src/main/scala/fi/vm/sade/hakurekisteri/integration/valintatulos/ValintaTulosActor.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/integration/valintatulos/ValintaTulosActor.scala
@@ -28,7 +28,7 @@ class ValintaTulosActor(client: VirkailijaRestClient,
   private val maxRetries: Int = config.integrations.valintaTulosConfig.httpClientMaxRetries
   private val refetch: FiniteDuration = refetchTime.map(_.milliseconds).getOrElse((config.integrations.valintatulosCacheHours / 2).hours)
   private val retry: FiniteDuration = retryTime.map(_.milliseconds).getOrElse(60.seconds)
-  private val cache = cacheFactory.getInstance[String, SijoitteluTulos](cacheTime.getOrElse(config.integrations.valintatulosCacheHours.hours.toMillis), getClass, "sijoittelu-tulos")
+  private val cache = cacheFactory.getInstance[String, SijoitteluTulos](cacheTime.getOrElse(config.integrations.valintatulosCacheHours.hours.toMillis), this.getClass, classOf[ValintaTulosToSijoitteluTulos], "sijoittelu-tulos")
   private var calling: Boolean = false
   private var initialLoadingDone = initOnStartup
   private val startTimeMillis: Long = System.currentTimeMillis()

--- a/src/test/scala/fi/vm/sade/hakurekisteri/integration/FutureCacheSpec.scala
+++ b/src/test/scala/fi/vm/sade/hakurekisteri/integration/FutureCacheSpec.scala
@@ -12,7 +12,7 @@ class FutureCacheSpec extends FlatSpec with Matchers {
 
   val cacheFactory = MockCacheFactory.get
 
-  def newCache(ttl: Long = 10.seconds.toMillis) = cacheFactory.getInstance[String, String](ttl, getClass, "moi")
+  def newCache(ttl: Long = 10.seconds.toMillis) = cacheFactory.getInstance[String, String](ttl, this.getClass, classOf[String], "moi")
     .asInstanceOf[InMemoryFutureCache[String,String]]
 
   behavior of "FutureCache"

--- a/src/test/scala/fi/vm/sade/hakurekisteri/integration/RedisCacheSpec.scala
+++ b/src/test/scala/fi/vm/sade/hakurekisteri/integration/RedisCacheSpec.scala
@@ -52,7 +52,7 @@ class RedisCacheSpec extends FlatSpec with Matchers with ActorSystemSupport with
 
         Thread.sleep(500)
 
-        Await.result(cache.contains(cacheKey), 1.second) should be(true)
+        cache.shouldContain(cacheKey)
 
         Await.result(cache.get(cacheKey, stringLoader), 10.seconds) should be (Some(cacheEntry))
       }
@@ -68,13 +68,13 @@ class RedisCacheSpec extends FlatSpec with Matchers with ActorSystemSupport with
 
         Thread.sleep(500)
 
-        Await.result(cache.contains(cacheKey), 1.second) should be(true)
+        cache.shouldContain(cacheKey)
 
         cache - cacheKey
 
         Thread.sleep(500)
 
-        Await.result(cache.contains(cacheKey), 1.second) should be(false)
+        cache.shouldNotContain(cacheKey)
       }
     )
   }
@@ -93,7 +93,7 @@ class RedisCacheSpec extends FlatSpec with Matchers with ActorSystemSupport with
       implicit system => {
         val cache = redisCacheFactory.getInstance[String,String](3.minutes.toMillis, getClass, "prefix3")
 
-        Await.result(cache.contains(cacheKey), 1.second) should be(true)
+        cache.shouldContain(cacheKey)
       }
     )
   }
@@ -113,8 +113,8 @@ class RedisCacheSpec extends FlatSpec with Matchers with ActorSystemSupport with
         val cache4 = redisCacheFactory.getInstance[String,String](3.minutes.toMillis, getClass, "prefix4")
         val cache5 =  redisCacheFactory.getInstance[String,String](3.minutes.toMillis, getClass, "prefix5")
 
-        Await.result(cache5.contains(cacheKey), 1.second) should be(false)
-        Await.result(cache4.contains(cacheKey), 1.second) should be(true)
+        cache5.shouldNotContain(cacheKey)
+        cache4.shouldContain(cacheKey)
       }
     )
   }
@@ -141,7 +141,7 @@ class RedisCacheSpec extends FlatSpec with Matchers with ActorSystemSupport with
            results.foreach(_ should be(Some(cacheEntry)))
 
            Thread.sleep(100)
-           Await.result(cache.contains(cacheKey), 1.second) should be(true)
+           cache.shouldContain(cacheKey)
            Await.result(cache.get(cacheKey, stringLoader), 1.second) should be (Some(cacheEntry))
 
            verify(mockLoader, times(1)).apply(cacheKey)
@@ -159,7 +159,7 @@ class RedisCacheSpec extends FlatSpec with Matchers with ActorSystemSupport with
 
         Thread.sleep(500)
 
-        Await.result(cache.contains("version"), 1.second) should be(true)
+        cache.shouldContain("version")
         Await.result(cache.getVersion, 1.second) should be(Some(javaStringSerialVersionUID))
       }
     )
@@ -174,7 +174,7 @@ class RedisCacheSpec extends FlatSpec with Matchers with ActorSystemSupport with
 
         Thread.sleep(500)
 
-        Await.result(cacheOfStrings.contains("version"), 1.second) should be(true)
+        cacheOfStrings.shouldContain("version")
 
         Await.result(cacheOfStrings.getVersion, 1.second) shouldBe Some(javaStringSerialVersionUID)
 
@@ -188,7 +188,7 @@ class RedisCacheSpec extends FlatSpec with Matchers with ActorSystemSupport with
     )
   }
 
-  it should "clear cache when version changes" in {
+  it should "clear cache when the version changes" in {
     withSystem(
       implicit system => {
         val cacheOfStrings = redisCacheFactory.getInstance[String,String](3.minutes.toMillis, getClass, "prefix8")
@@ -197,19 +197,19 @@ class RedisCacheSpec extends FlatSpec with Matchers with ActorSystemSupport with
 
         Thread.sleep(500)
 
-        Await.result(cacheOfStrings.contains(cacheKey), 1.second) should be(true)
+        cacheOfStrings.shouldContain(cacheKey)
 
         val cacheOfThrowables = redisCacheFactory.getInstance[String,Throwable](3.minutes.toMillis, getClass, "prefix8")
 
         Thread.sleep(500)
 
-        Await.result(cacheOfStrings.contains(cacheKey), 1.second) should be(false)
-        Await.result(cacheOfThrowables.contains(cacheKey), 1.second) should be(false)
+        cacheOfStrings.shouldNotContain(cacheKey)
+        cacheOfThrowables.shouldNotContain(cacheKey)
       }
     )
   }
 
-  it should "not clear cache when creating new instance with same version" in {
+  it should "not clear cache when creating a new instance with same version" in {
     withSystem(
       implicit system => {
         val cache1 = redisCacheFactory.getInstance[String,String](3.minutes.toMillis, getClass, "prefix9")
@@ -218,20 +218,20 @@ class RedisCacheSpec extends FlatSpec with Matchers with ActorSystemSupport with
 
         Thread.sleep(500)
 
-        Await.result(cache1.contains(cacheKey), 1.second) should be(true)
+        cache1.shouldContain(cacheKey)
 
         val cache2 = redisCacheFactory.getInstance[String,String](3.minutes.toMillis, getClass, "prefix9")
 
         Thread.sleep(500)
 
-        Await.result(cache1.contains(cacheKey), 1.second) should be(true)
-        Await.result(cache2.contains(cacheKey), 1.second) should be(true)
+        cache1.shouldContain(cacheKey)
+        cache2.shouldContain(cacheKey)
         Await.result(cache1.get(cacheKey, stringLoader), 1.second) should be(Await.result(cache2.get(cacheKey, stringLoader), 1.second))
       }
     )
   }
 
-  it should "not clear other caches when one changes" in {
+  it should "not clear other caches when one cache changes" in {
     withSystem(
       implicit system => {
         val cacheOfStrings1  = redisCacheFactory.getInstance[String,String](3.minutes.toMillis, getClass, "prefix10")
@@ -243,31 +243,28 @@ class RedisCacheSpec extends FlatSpec with Matchers with ActorSystemSupport with
 
         Thread.sleep(500)
 
-        Await.result(cacheOfStrings1.contains(cacheKey), 1.second) should be(true)
-        Await.result(cacheOfStrings2.contains(anotherKey), 1.second) should be(true)
-        Await.result(cacheOfStrings1.contains(anotherKey), 1.second) should be(false)
-        Await.result(cacheOfStrings2.contains(cacheKey), 1.second) should be(false)
+        cacheOfStrings1.shouldContain(cacheKey)
+        cacheOfStrings2.shouldContain(anotherKey)
+        cacheOfStrings1.shouldNotContain(anotherKey)
+        cacheOfStrings2.shouldNotContain(cacheKey)
 
         val cacheOfThrowables = redisCacheFactory.getInstance[String,Throwable](3.minutes.toMillis, getClass, "prefix10")
 
         Thread.sleep(500)
 
-        Await.result(cacheOfStrings1.contains(cacheKey), 1.second) should be(false)
-        Await.result(cacheOfStrings2.contains(anotherKey), 1.second) should be(true)
+        cacheOfStrings1.shouldNotContain(cacheKey)
+        cacheOfStrings2.shouldContain(anotherKey)
       }
     )
   }
 
-  def shouldContain(implicit cache: MonadCache[Future, String, Any], key: String): Unit = {
-    containsShouldBe(cache, key, expected = true)
-  }
+  implicit class EnrichedCache[T](val cache: MonadCache[Future, String, T]) {
+    def shouldContain(key: String): Unit = containsShouldBe(this.cache, key, expected = true)
+    def shouldNotContain(key: String): Unit = containsShouldBe(this.cache, key, expected = false)
 
-  def shouldNotContain(cache: MonadCache[Future, String, Any], key: String): Unit = {
-    containsShouldBe(cache, key, expected = false)
-  }
-
-  def containsShouldBe(cache: MonadCache[Future, String, Any], key: String, expected: Boolean): Unit = {
-    Await.result(cache.contains(key), 1.second) should be(expected)
+    def containsShouldBe[T](cache: MonadCache[Future, String, T], key: String, expected: Boolean): Unit = {
+      Await.result(cache.contains(key), 1.second) should be(expected)
+    }
   }
 
   override def afterAll() = {

--- a/src/test/scala/fi/vm/sade/hakurekisteri/integration/RedisCacheSpec.scala
+++ b/src/test/scala/fi/vm/sade/hakurekisteri/integration/RedisCacheSpec.scala
@@ -1,6 +1,7 @@
 package fi.vm.sade.hakurekisteri.integration
 
 import akka.actor.ActorSystem
+import fi.vm.sade.hakurekisteri.integration.cache.CacheFactory.RedisCacheInitializationException
 import fi.vm.sade.hakurekisteri.integration.cache.{CacheFactory, MonadCache}
 import fi.vm.sade.hakurekisteri.integration.koodisto.GetRinnasteinenKoodiArvoQuery
 import fi.vm.sade.hakurekisteri.integration.tarjonta.Hakukohde
@@ -284,6 +285,16 @@ class RedisCacheSpec extends FlatSpec with Matchers with ActorSystemSupport with
         val koodiVersion = Await.result(cacheOfKoodis.getVersion, 1.minute).get
 
         koodiVersion shouldNot be(hakukohdeVersion)
+      }
+    )
+  }
+
+  it should "throw an exception if initializing cache with non-serializable classOfT" in {
+    withSystem(
+      implicit system => {
+        intercept[RedisCacheInitializationException] {
+          redisCacheFactory.getInstance[String, String](3.minutes.toMillis, this.getClass, classOf[ActorSystem], "prefix15")
+        }
       }
     )
   }

--- a/src/test/scala/fi/vm/sade/hakurekisteri/integration/valintatulos/ValintaTulosActorWithRedisSpec.scala
+++ b/src/test/scala/fi/vm/sade/hakurekisteri/integration/valintatulos/ValintaTulosActorWithRedisSpec.scala
@@ -72,7 +72,7 @@ class ValintaTulosActorWithRedisSpec extends ScalatraFunSuite with FutureWaiting
         })
 
         val cached = Await.result(cacheFactory.getInstance[String, SijoitteluTulos](1111,
-          classOf[ValintaTulosActor], classOf[ValintaTulosActor], "sijoittelu-tulos").get("1.2.246.562.29.90697286251", (_: String) => Future.failed(new RuntimeException("should not be called"))), 10.seconds)
+          classOf[ValintaTulosActor], classOf[SijoitteluTulos], "sijoittelu-tulos").get("1.2.246.562.29.90697286251", (_: String) => Future.failed(new RuntimeException("should not be called"))), 10.seconds)
         cached.get.valintatila("1.2.246.562.11.00000000576", "1.2.246.562.20.25463238029").get.toString should be (Valintatila.KESKEN.toString)
 
         verify(endPoint, times(1)).request(forUrl("http://localhost/valinta-tulos-service/haku/1.2.246.562.29.90697286251"))
@@ -129,7 +129,7 @@ class ValintaTulosActorWithRedisSpec extends ScalatraFunSuite with FutureWaiting
         })
 
         val cached = Await.result(cacheFactory.getInstance[String, SijoitteluTulos](1111,
-          classOf[ValintaTulosActor], classOf[ValintaTulosActor], "sijoittelu-tulos").get("1.2.246.562.29.90697286253", (_: String) => Future.failed(new RuntimeException("should not be called"))), 10.seconds)
+          classOf[ValintaTulosActor], classOf[SijoitteluTulos], "sijoittelu-tulos").get("1.2.246.562.29.90697286253", (_: String) => Future.failed(new RuntimeException("should not be called"))), 10.seconds)
         cached.get.valintatila("1.2.246.562.11.00000000576", "1.2.246.562.20.25463238029").get.toString should be (Valintatila.KESKEN.toString)
 
         verify(endPoint, times(1)).request(forUrl("http://localhost/valinta-tulos-service/haku/1.2.246.562.29.90697286253"))
@@ -199,7 +199,7 @@ class ValintaTulosActorWithRedisSpec extends ScalatraFunSuite with FutureWaiting
 
         Thread.sleep(300)
 
-        val cache = cacheFactory.getInstance[String, SijoitteluTulos](1111, classOf[ValintaTulosActor], classOf[ValintaTulosActor], "sijoittelu-tulos")
+        val cache = cacheFactory.getInstance[String, SijoitteluTulos](1111, classOf[ValintaTulosActor], classOf[SijoitteluTulos], "sijoittelu-tulos")
         Await.result(cache.contains("1.2.246.562.29.11"), 1.second) should be(true)
         Await.result(cache.contains("1.2.246.562.29.12"), 1.second) should be(true)
         Await.result(cache.contains("1.2.246.562.29.13"), 1.second) should be(false)
@@ -226,7 +226,7 @@ class ValintaTulosActorWithRedisSpec extends ScalatraFunSuite with FutureWaiting
 
         Thread.sleep(300)
 
-        val cache = cacheFactory.getInstance[String, SijoitteluTulos](1111, classOf[ValintaTulosActor], classOf[ValintaTulosActor], "sijoittelu-tulos")
+        val cache = cacheFactory.getInstance[String, SijoitteluTulos](1111, classOf[ValintaTulosActor], classOf[SijoitteluTulos], "sijoittelu-tulos")
         Await.result(cache.contains("1.2.246.562.29.11"), 1.second) should be(true)
         Await.result(cache.contains("1.2.246.562.29.12"), 1.second) should be(true)
         Await.result(cache.contains("1.2.246.562.29.13"), 1.second) should be(true)

--- a/src/test/scala/fi/vm/sade/hakurekisteri/integration/valintatulos/ValintaTulosActorWithRedisSpec.scala
+++ b/src/test/scala/fi/vm/sade/hakurekisteri/integration/valintatulos/ValintaTulosActorWithRedisSpec.scala
@@ -72,7 +72,7 @@ class ValintaTulosActorWithRedisSpec extends ScalatraFunSuite with FutureWaiting
         })
 
         val cached = Await.result(cacheFactory.getInstance[String, SijoitteluTulos](1111,
-          classOf[ValintaTulosActor], "sijoittelu-tulos").get("1.2.246.562.29.90697286251", (_: String) => Future.failed(new RuntimeException("should not be called"))), 10.seconds)
+          classOf[ValintaTulosActor], classOf[ValintaTulosActor], "sijoittelu-tulos").get("1.2.246.562.29.90697286251", (_: String) => Future.failed(new RuntimeException("should not be called"))), 10.seconds)
         cached.get.valintatila("1.2.246.562.11.00000000576", "1.2.246.562.20.25463238029").get.toString should be (Valintatila.KESKEN.toString)
 
         verify(endPoint, times(1)).request(forUrl("http://localhost/valinta-tulos-service/haku/1.2.246.562.29.90697286251"))
@@ -129,7 +129,7 @@ class ValintaTulosActorWithRedisSpec extends ScalatraFunSuite with FutureWaiting
         })
 
         val cached = Await.result(cacheFactory.getInstance[String, SijoitteluTulos](1111,
-          classOf[ValintaTulosActor], "sijoittelu-tulos").get("1.2.246.562.29.90697286253", (_: String) => Future.failed(new RuntimeException("should not be called"))), 10.seconds)
+          classOf[ValintaTulosActor], classOf[ValintaTulosActor], "sijoittelu-tulos").get("1.2.246.562.29.90697286253", (_: String) => Future.failed(new RuntimeException("should not be called"))), 10.seconds)
         cached.get.valintatila("1.2.246.562.11.00000000576", "1.2.246.562.20.25463238029").get.toString should be (Valintatila.KESKEN.toString)
 
         verify(endPoint, times(1)).request(forUrl("http://localhost/valinta-tulos-service/haku/1.2.246.562.29.90697286253"))
@@ -199,7 +199,7 @@ class ValintaTulosActorWithRedisSpec extends ScalatraFunSuite with FutureWaiting
 
         Thread.sleep(300)
 
-        val cache = cacheFactory.getInstance[String, SijoitteluTulos](1111, classOf[ValintaTulosActor], "sijoittelu-tulos")
+        val cache = cacheFactory.getInstance[String, SijoitteluTulos](1111, classOf[ValintaTulosActor], classOf[ValintaTulosActor], "sijoittelu-tulos")
         Await.result(cache.contains("1.2.246.562.29.11"), 1.second) should be(true)
         Await.result(cache.contains("1.2.246.562.29.12"), 1.second) should be(true)
         Await.result(cache.contains("1.2.246.562.29.13"), 1.second) should be(false)
@@ -226,7 +226,7 @@ class ValintaTulosActorWithRedisSpec extends ScalatraFunSuite with FutureWaiting
 
         Thread.sleep(300)
 
-        val cache = cacheFactory.getInstance[String, SijoitteluTulos](1111, classOf[ValintaTulosActor], "sijoittelu-tulos")
+        val cache = cacheFactory.getInstance[String, SijoitteluTulos](1111, classOf[ValintaTulosActor], classOf[ValintaTulosActor], "sijoittelu-tulos")
         Await.result(cache.contains("1.2.246.562.29.11"), 1.second) should be(true)
         Await.result(cache.contains("1.2.246.562.29.12"), 1.second) should be(true)
         Await.result(cache.contains("1.2.246.562.29.13"), 1.second) should be(true)


### PR DESCRIPTION
Ongelma:

Luokkien Redikseen kirjoituksessa käytetään Javan serialisaatiota, mikä luo automaattisesti serialVersionUID:n. Kun luokalle esim. lisätään metodi, sen serialVersionUID muuttuu, jolloin deserialisointi ei enää onnistu. Tämän exceptionin havaitseminen ei onnistu käytetyllä ajurilla.

Ratkaisu:

Redis cacheen tallennetaan serialVersionUID (Javan automaattisesti generoima). Cachen initialisoinnissa (JARin käynnistyessä) tarkistetaan, onko cacheen kirjoitettu serialVersionUID sama kuin nyt JARissa olevan luokan serialVersionUID. Jos ei, tiedetään että luokka on muuttunut, jolloin tyhjennetään koko cache ja tallennetaan sinne uusi serialVersionUID.
