### PR TITLE
Ksk 2 sulkeminen

### DIFF
--- a/src/main/scala/fi/vm/sade/hakurekisteri/integration/koski/KoskiUtil.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/integration/koski/KoskiUtil.scala
@@ -10,6 +10,7 @@ object KoskiUtil {
 
   val koski_integration_source = "koski"
   var deadlineDate: LocalDate = new LocalDate(OphUrlProperties.getProperty("suoritusrekisteri.koski.deadline.date"))
+  lazy val koskiIntegrationInUse: Boolean = OphUrlProperties.getProperty("suoritusrekisteri.use.koski.integration").toBoolean
 
   def isAfterArvosanatWithNelosiaDeadlineDate(): Boolean = {
     // Neloset halutaan tallentaa suoritusrekisteriin kaksi viikkoa ennen deadline-päivämäärää

--- a/src/main/scala/fi/vm/sade/hakurekisteri/web/koski/KoskiImporterResource.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/web/koski/KoskiImporterResource.scala
@@ -5,7 +5,7 @@ import akka.event.{Logging, LoggingAdapter}
 import org.scalatra.json.JacksonJsonSupport
 import fi.vm.sade.auditlog.{Audit, Changes, Target}
 import fi.vm.sade.hakurekisteri._
-import fi.vm.sade.hakurekisteri.integration.koski.{IKoskiService, KoskiService, KoskiSuoritusHakuParams}
+import fi.vm.sade.hakurekisteri.integration.koski.{IKoskiService, KoskiService, KoskiSuoritusHakuParams, KoskiUtil}
 import fi.vm.sade.hakurekisteri.rest.support.{HakurekisteriJsonSupport, User}
 import fi.vm.sade.hakurekisteri.web.HakuJaValintarekisteriStack
 import fi.vm.sade.hakurekisteri.web.rest.support.{Security, SecuritySupport, UserNotAuthorized}
@@ -40,8 +40,8 @@ class KoskiImporterResource(koskiService: IKoskiService, ophConfig: Config)
   }
 
   get("/:oppijaOid", operation(read)) {
-
     implicit val user: User = getAdmin
+    if (!KoskiUtil.koskiIntegrationInUse) throw new RuntimeException(s"Koski-Integration is disabled by an env parameter!")
     val personOid = params("oppijaOid")
     val haeLukio: Boolean = params.getAsOrElse("haelukio", false)
     val haeAmmatilliset: Boolean = params.getAsOrElse("haeammatilliset", false)
@@ -60,6 +60,7 @@ class KoskiImporterResource(koskiService: IKoskiService, ophConfig: Config)
 
   post("/oppijat", operation(updateHenkilot)) {
     implicit val user: User = getAdmin
+    if (!KoskiUtil.koskiIntegrationInUse) throw new RuntimeException(s"Koski-Integration is disabled by an env parameter!")
     val personOids = parse(request.body).extract[Set[String]]
     val haeLukio: Boolean = params.getAsOrElse("haelukio", false)
     val haeAmmatilliset: Boolean = params.getAsOrElse("haeammatilliset", false)
@@ -81,6 +82,7 @@ class KoskiImporterResource(koskiService: IKoskiService, ophConfig: Config)
 
   get("/haku/:hakuOid", operation(updateForHaku)) {
     implicit val user: User = getAdmin
+    if (!KoskiUtil.koskiIntegrationInUse) throw new RuntimeException(s"Koski-Integration is disabled by an env parameter!")
     val hakuOid = params("hakuOid")
     val haeLukio: Boolean = params.getAsOrElse("haelukio", false)
     val haeAmmatilliset: Boolean = params.getAsOrElse("haeammatilliset", false)

--- a/src/main/scala/support/Integrations.scala
+++ b/src/main/scala/support/Integrations.scala
@@ -210,7 +210,7 @@ class BaseIntegrations(rekisterit: Registers,
   quartzScheduler.scheduleJob(lambdaJob(rerunSync),
     newTrigger().startNow().withSchedule(cronSchedule(syncAllCronExpression)).build());
 
-  if (Try(config.properties.getOrElse("suoritusrekisteri.use.koski.integration", "true").toBoolean).getOrElse(true)) {
+  if (KoskiUtil.koskiIntegrationInUse) {
     koskiService.refreshChangedOppijasFromKoski()
     val koskiCronJob = OphUrlProperties.getProperty("suoritusrekisteri.koski.update.cronJob")
     quartzScheduler.scheduleJob(lambdaJob(koskiService.updateAktiivisetHaut()),

--- a/src/main/scala/support/Integrations.scala
+++ b/src/main/scala/support/Integrations.scala
@@ -215,6 +215,8 @@ class BaseIntegrations(rekisterit: Registers,
     val koskiCronJob = OphUrlProperties.getProperty("suoritusrekisteri.koski.update.cronJob")
     quartzScheduler.scheduleJob(lambdaJob(koskiService.updateAktiivisetHaut()),
       newTrigger().startNow().withSchedule(cronSchedule(koskiCronJob)).build())
+  } else {
+    logger.info("Koski-integration has been disabled by env parameter.")
   }
 
   override val hakemusBasedPermissionChecker: HakemusBasedPermissionCheckerActorRef =


### PR DESCRIPTION
AIemmin koskiImporterResourcea ("mahtikäsky") pystyi käyttämään vaikka koski-integraatio olisi muuten ollut suljettuna ympäristössä. Tämän myötä ei enää pysty.
