### PR TITLE
BUG-1981 valinta tulos cache improvement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ tmp/*
 
 # java specific
 *.class
+.java-version
 
 # python specific
 *.pyc

--- a/src/main/scala/fi/vm/sade/hakurekisteri/integration/valintatulos/ValintaTulosActor.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/integration/valintatulos/ValintaTulosActor.scala
@@ -20,14 +20,12 @@ case class ValintaTulosQuery(hakuOid: String, hakemusOid: Option[String])
 class ValintaTulosActor(client: VirkailijaRestClient,
                         config: Config,
                         cacheFactory: CacheFactory,
-                        refetchTime: Option[Long] = None,
                         cacheTime: Option[Long] = None,
                         retryTime: Option[Long] = None,
                         initOnStartup: Boolean = false) extends Actor with ActorLogging {
 
   implicit val ec: ExecutionContext = ExecutorUtil.createExecutor(config.integrations.asyncOperationThreadPoolSize, getClass.getSimpleName)
   private val maxRetries: Int = config.integrations.valintaTulosConfig.httpClientMaxRetries
-  private val refetch: FiniteDuration = refetchTime.map(_.milliseconds).getOrElse((config.integrations.valintatulosCacheHours / 2).hours)
   private val retry: FiniteDuration = retryTime.map(_.milliseconds).getOrElse(60.seconds)
   private val cache = cacheFactory.getInstance[String, SijoitteluTulos](cacheTime.getOrElse(config.integrations.valintatulosCacheHours.hours.toMillis), this.getClass, classOf[SijoitteluTulos], "sijoittelu-tulos")
   private var calling: Boolean = false

--- a/src/main/scala/fi/vm/sade/hakurekisteri/integration/valintatulos/ValintaTulosActor.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/integration/valintatulos/ValintaTulosActor.scala
@@ -45,21 +45,9 @@ class ValintaTulosActor(client: VirkailijaRestClient,
       self ! UpdateNext
 
     case BatchUpdateValintatulos(haut) =>
-      Future.sequence(haut.map(h => Future.successful(h).zip(cache.contains(h.haku)))).map { updatesWithContainsFlags: Set[(UpdateValintatulos, Boolean)] =>
-        updatesWithContainsFlags.groupBy(_._2).mapValues(_.map(_._1))
-      }.onComplete { result =>
-        result match {
-          case Success(updatesByContains) =>
-            val hautCachessa = updatesByContains.get(true)
-            log.info(s"Skipping ${hautCachessa.map(_.size).getOrElse(0)} hakus (${hautCachessa.map(_.map(_.haku)).mkString(", ")}) from initial loading.")
-            val hautEiCachessa = updatesByContains.get(false)
-            hautEiCachessa.foreach(_.foreach(haku =>
-              if (!updateRequestQueue.contains(haku.haku)) updateRequestQueue = updateRequestQueue + (haku.haku -> Seq())))
-          case Failure(e) =>
-            log.error(e, s"Problem when checking contains from cache. Cannot process ${BatchUpdateValintatulos.getClass.getSimpleName} with ${haut.size} haut.")
-        }
-        self ! UpdateNext
-      }
+      haut.foreach(haku =>
+        if (!updateRequestQueue.contains(haku.haku)) updateRequestQueue = updateRequestQueue + (haku.haku -> Seq()))
+      self ! UpdateNext
 
     case UpdateValintatulos(haku) =>
       if (!updateRequestQueue.contains(haku)) {

--- a/src/test/scala/fi/vm/sade/hakurekisteri/integration/valintatulos/ValintaTulosActorSpec.scala
+++ b/src/test/scala/fi/vm/sade/hakurekisteri/integration/valintatulos/ValintaTulosActorSpec.scala
@@ -67,7 +67,6 @@ class ValintaTulosActorSpec extends ScalatraFunSuite with FutureWaiting with Dis
           config = config,
           cacheFactory = cacheFactory,
           client = new VirkailijaRestClient(config = vtsConfig, aClient = Some(new CapturingAsyncHttpClient(endPoint))),
-          refetchTime = Some(1000),
           cacheTime = Some(2000)
         )))
 
@@ -89,7 +88,6 @@ class ValintaTulosActorSpec extends ScalatraFunSuite with FutureWaiting with Dis
           config = config,
           cacheFactory = cacheFactory,
           client = new VirkailijaRestClient(config = vtsConfig, aClient = Some(new CapturingAsyncHttpClient(endPoint))),
-          refetchTime = Some(500),
           cacheTime = Some(1000)
         )))
 
@@ -120,7 +118,6 @@ class ValintaTulosActorSpec extends ScalatraFunSuite with FutureWaiting with Dis
           config = config,
           cacheFactory = cacheFactory,
           client = new VirkailijaRestClient(config = vtsConfig, aClient = Some(new CapturingAsyncHttpClient(endPoint))),
-          refetchTime = Some(500),
           cacheTime = Some(1000),
           retryTime = Some(100)
         )))

--- a/src/test/scala/fi/vm/sade/hakurekisteri/integration/valintatulos/ValintaTulosActorSpec.scala
+++ b/src/test/scala/fi/vm/sade/hakurekisteri/integration/valintatulos/ValintaTulosActorSpec.scala
@@ -58,7 +58,7 @@ class ValintaTulosActorSpec extends ScalatraFunSuite with FutureWaiting with Dis
     )
   }
 
-  test("ValintaTulosActor should update cache periodically") {
+  test("ValintaTulosActor should update cache") {
     withSystem(
       implicit system => {
         implicit val ec = system.dispatcher

--- a/src/test/scala/fi/vm/sade/hakurekisteri/integration/valintatulos/ValintaTulosActorWithRedisSpec.scala
+++ b/src/test/scala/fi/vm/sade/hakurekisteri/integration/valintatulos/ValintaTulosActorWithRedisSpec.scala
@@ -156,7 +156,7 @@ class ValintaTulosActorWithRedisSpec extends ScalatraFunSuite with FutureWaiting
     )
   }
 
-  test("ValintaTulosActor should skip initial loading if data is already in redis") {
+  test("ValintaTulosActor should load even if data is already in redis") {
     withSystem(
       implicit system => {
         implicit val ec = system.dispatcher
@@ -179,8 +179,10 @@ class ValintaTulosActorWithRedisSpec extends ScalatraFunSuite with FutureWaiting
         Await.result(cache.contains("1.2.246.562.29.13"), 1.second) should be(false)
         Await.result(cache.contains("1.2.246.562.29.14"), 1.second) should be(false)
 
-        verify(endPoint).request(forUrl("http://localhost/valinta-tulos-service/haku/1.2.246.562.29.11"))
-        verify(endPoint).request(forUrl("http://localhost/valinta-tulos-service/haku/1.2.246.562.29.12"))
+        verify(endPoint, times(1)).request(forUrl("http://localhost/valinta-tulos-service/haku/1.2.246.562.29.11"))
+        verify(endPoint, times(1)).request(forUrl("http://localhost/valinta-tulos-service/haku/1.2.246.562.29.12"))
+        verify(endPoint, never()).request(forUrl("http://localhost/valinta-tulos-service/haku/1.2.246.562.29.13"))
+        verify(endPoint, never()).request(forUrl("http://localhost/valinta-tulos-service/haku/1.2.246.562.29.14"))
       }
     )
     withSystem(
@@ -205,8 +207,8 @@ class ValintaTulosActorWithRedisSpec extends ScalatraFunSuite with FutureWaiting
         Await.result(cache.contains("1.2.246.562.29.13"), 1.second) should be(true)
         Await.result(cache.contains("1.2.246.562.29.14"), 1.second) should be(true)
 
-        verify(endPoint, never()).request(forUrl("http://localhost/valinta-tulos-service/haku/1.2.246.562.29.11"))
-        verify(endPoint, never()).request(forUrl("http://localhost/valinta-tulos-service/haku/1.2.246.562.29.12"))
+        verify(endPoint).request(forUrl("http://localhost/valinta-tulos-service/haku/1.2.246.562.29.11"))
+        verify(endPoint).request(forUrl("http://localhost/valinta-tulos-service/haku/1.2.246.562.29.12"))
         verify(endPoint).request(forUrl("http://localhost/valinta-tulos-service/haku/1.2.246.562.29.13"))
         verify(endPoint).request(forUrl("http://localhost/valinta-tulos-service/haku/1.2.246.562.29.14"))
       }

--- a/src/test/scala/fi/vm/sade/hakurekisteri/integration/valintatulos/ValintaTulosActorWithRedisSpec.scala
+++ b/src/test/scala/fi/vm/sade/hakurekisteri/integration/valintatulos/ValintaTulosActorWithRedisSpec.scala
@@ -88,7 +88,6 @@ class ValintaTulosActorWithRedisSpec extends ScalatraFunSuite with FutureWaiting
           config = config,
           cacheFactory = cacheFactory,
           client = new VirkailijaRestClient(config = vtsConfig, aClient = Some(new CapturingAsyncHttpClient(endPoint))),
-          refetchTime = Some(1000),
           cacheTime = Some(2000)
         )))
 
@@ -110,7 +109,6 @@ class ValintaTulosActorWithRedisSpec extends ScalatraFunSuite with FutureWaiting
           config = config,
           cacheFactory = cacheFactory,
           client = new VirkailijaRestClient(config = vtsConfig, aClient = Some(new CapturingAsyncHttpClient(endPoint))),
-          refetchTime = Some(500),
           cacheTime = Some(1000)
         )))
 
@@ -145,7 +143,6 @@ class ValintaTulosActorWithRedisSpec extends ScalatraFunSuite with FutureWaiting
           config = config,
           cacheFactory = cacheFactory,
           client = new VirkailijaRestClient(config = vtsConfig, aClient = Some(new CapturingAsyncHttpClient(endPoint))),
-          refetchTime = Some(500),
           cacheTime = Some(1000),
           retryTime = Some(100)
         )))
@@ -168,7 +165,6 @@ class ValintaTulosActorWithRedisSpec extends ScalatraFunSuite with FutureWaiting
           config = config,
           cacheFactory = cacheFactory,
           client = new VirkailijaRestClient(config = vtsConfig, aClient = Some(new CapturingAsyncHttpClient(endPoint))),
-          refetchTime = Some(500),
           cacheTime = Some(1000),
           retryTime = Some(100)
         )))
@@ -195,7 +191,6 @@ class ValintaTulosActorWithRedisSpec extends ScalatraFunSuite with FutureWaiting
           config = config,
           cacheFactory = cacheFactory,
           client = new VirkailijaRestClient(config = vtsConfig, aClient = Some(new CapturingAsyncHttpClient(endPoint))),
-          refetchTime = Some(500),
           cacheTime = Some(1000),
           retryTime = Some(100)
         )))


### PR DESCRIPTION
`HakuActor` has the responsibility to refresh the cache which is within `ValintaTulosActor`. This refresh operation will simply reload *all* active haku results. The time between two refreshes (`valintatulosRefreshTimeHours`) *must be shorter* than the cache expiration time (`valintatulosCacheHours`), so that it never happens that active haku results are expired. 

Problem was before when `ValintaTulosActor` was not updating the active haut that are already in cache, and they could unnecessarily expire. 