### PR TITLE
Bug 2157 koskibatchienvirheet

### DIFF
--- a/src/main/scala/fi/vm/sade/hakurekisteri/integration/koski/KoskiService.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/integration/koski/KoskiService.scala
@@ -155,7 +155,7 @@ class KoskiService(virkailijaRestClient: VirkailijaRestClient,
             case e: Exception =>
               if (retriesLeft > 0) {
                 logger.error(e, s"HandleHenkiloUpdate ($description) Virhe päivitettäessä henkilöiden tietoja erässä $era / $totalGroups, yritetään uudelleen. Uudelleenyrityksiä jäljellä: $retriesLeft")
-                Future { Thread.sleep(10000) }.flatMap(_ => updateHenkilotWithRetries(oppijaOids, params, era, retriesLeft - 1))
+                Future { Thread.sleep(params.retryWaitMillis) }.flatMap(_ => updateHenkilotWithRetries(oppijaOids, params, era, retriesLeft - 1))
               } else {
                 logger.error(e, s"HandleHenkiloUpdate ($description) Virhe päivitettäessä henkilöiden tietoja erässä $era / $totalGroups, ei enää uudelleenyrityksiä jäljellä.")
                 throw e

--- a/src/main/scala/fi/vm/sade/hakurekisteri/integration/koski/KoskiService.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/integration/koski/KoskiService.scala
@@ -155,7 +155,7 @@ class KoskiService(virkailijaRestClient: VirkailijaRestClient,
             case e: Exception =>
               if (retriesLeft > 0) {
                 logger.error(e, s"HandleHenkiloUpdate ($description) Virhe päivitettäessä henkilöiden tietoja erässä $era / $totalGroups, yritetään uudelleen. Uudelleenyrityksiä jäljellä: $retriesLeft")
-                updateHenkilotWithRetries(oppijaOids, params, era, retriesLeft - 1)
+                Future { Thread.sleep(10000) }.flatMap(_ => updateHenkilotWithRetries(oppijaOids, params, era, retriesLeft - 1))
               } else {
                 logger.error(e, s"HandleHenkiloUpdate ($description) Virhe päivitettäessä henkilöiden tietoja erässä $era / $totalGroups, ei enää uudelleenyrityksiä jäljellä.")
                 throw e

--- a/src/main/scala/fi/vm/sade/hakurekisteri/integration/koski/KoskiService.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/integration/koski/KoskiService.scala
@@ -139,7 +139,7 @@ class KoskiService(virkailijaRestClient: VirkailijaRestClient,
 
   def handleHenkiloUpdate(personOids: Seq[String], params: KoskiSuoritusHakuParams, description: String = ""): Future[Unit] = {
     if (personOids.isEmpty) {
-      logger.info("HandleHenkiloUpdate : no personOids to process.")
+      logger.info(s"HandleHenkiloUpdate ($description) no personOids to process.")
       Future.successful({})
     } else {
       logger.info(s"HandleHenkiloUpdate ($description) {} oppijanumeros", personOids.size)
@@ -147,7 +147,7 @@ class KoskiService(virkailijaRestClient: VirkailijaRestClient,
       val groupedOids: Seq[Seq[String]] = personOids.grouped(maxOppijatBatchSize).toSeq
       val totalGroups: Int = groupedOids.length
       var updateHenkiloResults = (Seq[String](), Seq[String]())
-      logger.info(s"HandleHenkiloUpdate: ($description) yhteensä $totalGroups kappaletta $maxOppijatBatchSize kokoisia ryhmiä.")
+      logger.info(s"HandleHenkiloUpdate ($description) yhteensä $totalGroups kappaletta $maxOppijatBatchSize kokoisia ryhmiä.")
 
       def handleBatch(batches: Seq[(Seq[String], Int)], acc: (Seq[String], Seq[String])): Future[(Seq[String], Seq[String])] = {
         def updateHenkilotWithRetries(oppijaOids: Set[String], params: KoskiSuoritusHakuParams, era: Int, retriesLeft: Int): Future[(Seq[String], Seq[String])] = {
@@ -165,7 +165,7 @@ class KoskiService(virkailijaRestClient: VirkailijaRestClient,
           Future(acc)
         } else {
           val (subSeq, index) = batches.head
-          logger.info(s"HandleHenkiloUpdate ($description) Päivitetään Koskesta $maxOppijatBatchSize henkilöä sureen: Erä ${index+1} / $totalGroups.")
+          logger.info(s"HandleHenkiloUpdate ($description) Päivitetään Koskesta $maxOppijatBatchSize henkilön tiedot Sureen. Erä ${index+1} / $totalGroups.")
           updateHenkilotWithRetries(subSeq.toSet, params, index+1,3).flatMap(s => {
             logger.info(s"HandleHenkiloUpdate ($description) Erä ${index + 1} / $totalGroups käsitelty virheittä.")
             handleBatch(batches.tail, (s._1 ++ acc._1, s._2 ++ acc._2))

--- a/src/main/scala/fi/vm/sade/hakurekisteri/integration/koski/KoskiService.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/integration/koski/KoskiService.scala
@@ -166,7 +166,7 @@ class KoskiService(virkailijaRestClient: VirkailijaRestClient,
         } else {
           val (subSeq, index) = batches.head
           logger.info(s"HandleHenkiloUpdate ($description) Päivitetään Koskesta $maxOppijatBatchSize henkilön tiedot Sureen. Erä ${index+1} / $totalGroups.")
-          updateHenkilotWithRetries(subSeq.toSet, params, index+1,3).flatMap(s => {
+          updateHenkilotWithRetries(subSeq.toSet, params, index+1, retriesLeft = 3).flatMap(s => {
             logger.info(s"HandleHenkiloUpdate ($description) Erä ${index + 1} / $totalGroups käsitelty virheittä.")
             handleBatch(batches.tail, (s._1 ++ acc._1, s._2 ++ acc._2))
           })}

--- a/src/main/scala/fi/vm/sade/hakurekisteri/integration/koski/KoskiService.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/integration/koski/KoskiService.scala
@@ -64,7 +64,7 @@ class KoskiService(virkailijaRestClient: VirkailijaRestClient,
           case Success(response: MuuttuneetOppijatResponse) =>
             logger.info("refreshChangedOppijasFromKoski : got {} muuttunees oppijas from Koski.", response.result.size)
             val koskiParams = KoskiSuoritusHakuParams(saveLukio = false, saveAmmatillinen = false)
-            handleHenkiloUpdate(response.result, koskiParams).onComplete {
+            handleHenkiloUpdate(response.result, koskiParams, "refreshChangedOppijas").onComplete {
               case Success(s) =>
                 logger.info("refreshChangedOppijasFromKoski : batch handling success. Oppijas handled: {}", response.result.size)
                 if (response.mayHaveMore)
@@ -118,7 +118,7 @@ class KoskiService(virkailijaRestClient: VirkailijaRestClient,
         Duration(1, TimeUnit.MINUTES))
       val aliasCount: Int = personOidsWithAliases.henkiloOidsWithLinkedOids.size - personOidsSet.size
       logger.info(s"Saatiin hakemuspalvelusta ${personOidsSet.size} oppijanumeroa ja ${aliasCount} aliasta haulle $hakuOid")
-      handleHenkiloUpdate(personOidsWithAliases.henkiloOidsWithLinkedOids.toSeq, params)
+      handleHenkiloUpdate(personOidsWithAliases.henkiloOidsWithLinkedOids.toSeq, params, s"hakuOid: $hakuOid")
     }
     val now = System.currentTimeMillis()
     synchronized {
@@ -137,33 +137,44 @@ class KoskiService(virkailijaRestClient: VirkailijaRestClient,
     }
   }
 
-  def handleHenkiloUpdate(personOids: Seq[String], params: KoskiSuoritusHakuParams): Future[Unit] = {
+  def handleHenkiloUpdate(personOids: Seq[String], params: KoskiSuoritusHakuParams, description: String = ""): Future[Unit] = {
     if (personOids.isEmpty) {
       logger.info("HandleHenkiloUpdate : no personOids to process.")
       Future.successful({})
     } else {
-      logger.info("HandleHenkiloUpdate: {} oppijanumeros", personOids.size)
+      logger.info(s"HandleHenkiloUpdate ($description) {} oppijanumeros", personOids.size)
       val maxOppijatBatchSize: Int = config.integrations.koskiMaxOppijatBatchSize
       val groupedOids: Seq[Seq[String]] = personOids.grouped(maxOppijatBatchSize).toSeq
       val totalGroups: Int = groupedOids.length
       var updateHenkiloResults = (Seq[String](), Seq[String]())
-      logger.info(s"HandleHenkiloUpdate: yhteensä $totalGroups kappaletta $maxOppijatBatchSize kokoisia ryhmiä.")
+      logger.info(s"HandleHenkiloUpdate: ($description) yhteensä $totalGroups kappaletta $maxOppijatBatchSize kokoisia ryhmiä.")
 
       def handleBatch(batches: Seq[(Seq[String], Int)], acc: (Seq[String], Seq[String])): Future[(Seq[String], Seq[String])] = {
+        def updateHenkilotWithRetries(oppijaOids: Set[String], params: KoskiSuoritusHakuParams, era: Int, retriesLeft: Int): Future[(Seq[String], Seq[String])] = {
+          updateHenkilot(oppijaOids, params).recoverWith({
+            case e: Exception =>
+              if (retriesLeft > 0) {
+                logger.error(e, s"HandleHenkiloUpdate ($description) Virhe päivitettäessä henkilöiden tietoja erässä $era / $totalGroups, yritetään uudelleen. Uudelleenyrityksiä jäljellä: $retriesLeft")
+                updateHenkilotWithRetries(oppijaOids, params, era, retriesLeft - 1)
+              } else {
+                logger.error(e, s"HandleHenkiloUpdate ($description) Virhe päivitettäessä henkilöiden tietoja erässä $era / $totalGroups, ei enää uudelleenyrityksiä jäljellä.")
+                throw e
+              }})}
+
         if (batches.isEmpty) {
           Future(acc)
         } else {
           val (subSeq, index) = batches.head
-          logger.info(s"HandleHenkiloUpdate: Päivitetään Koskesta $maxOppijatBatchSize henkilöä sureen. Erä $index / $totalGroups")
-          updateHenkilot(subSeq.toSet, params).flatMap(s => {
+          logger.info(s"HandleHenkiloUpdate ($description) Päivitetään Koskesta $maxOppijatBatchSize henkilöä sureen: Erä ${index+1} / $totalGroups.")
+          updateHenkilotWithRetries(subSeq.toSet, params, index+1,3).flatMap(s => {
+            logger.info(s"HandleHenkiloUpdate ($description) Erä ${index + 1} / $totalGroups käsitelty virheittä.")
             handleBatch(batches.tail, (s._1 ++ acc._1, s._2 ++ acc._2))
-          })
-        }
+          })}
       }
 
       val f: Future[(Seq[String], Seq[String])] = handleBatch(groupedOids.zipWithIndex, updateHenkiloResults)
       f.flatMap(results => {
-        logger.info(s"HandleHenkiloUpdate: Koskipäivitys valmistui! Päivitettiin yhteensä ${results._1.size + results._2.size} henkilöä. " +
+        logger.info(s"HandleHenkiloUpdate ($description) Koskipäivitys valmistui! Päivitettiin yhteensä ${results._1.size + results._2.size} henkilöä. " +
           s"Onnistuneita päivityksiä ${results._2.size}. " +
           s"Epäonnistuneita päivityksiä ${results._1.size}. " +
           s"Epäonnistuneet: ${results._1}.")
@@ -171,8 +182,8 @@ class KoskiService(virkailijaRestClient: VirkailijaRestClient,
       }
       ).recoverWith {
         case e: Exception =>
-          logger.error(e, "HandleHenkiloUpdate: Koskipäivitys epäonnistui")
-          Future.successful({})
+          logger.error(e, s"HandleHenkiloUpdate ($description) Koskipäivitys epäonnistui")
+          Future.failed(e)
       }
     }
   }

--- a/src/main/scala/fi/vm/sade/hakurekisteri/integration/koski/koskiDomain.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/integration/koski/koskiDomain.scala
@@ -219,6 +219,6 @@ case class KoskiLisatiedot(
 
 case class KoskiErityisenTuenPaatos(opiskeleeToimintaAlueittain: Option[Boolean])
 
-case class KoskiSuoritusHakuParams(saveLukio: Boolean = false, saveAmmatillinen: Boolean = false)
+case class KoskiSuoritusHakuParams(saveLukio: Boolean = false, saveAmmatillinen: Boolean = false, retryWaitMillis: Long = 10000)
 
 

--- a/src/main/scala/fi/vm/sade/hakurekisteri/integration/valintatulos/ValintaTulosActor.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/integration/valintatulos/ValintaTulosActor.scala
@@ -68,7 +68,6 @@ class ValintaTulosActor(hautActor: ActorRef,
         haut.filter(_.isActive).foreach(haku => self ! FetchHaunValintatulos(haku.oid))
 
       case tulos: SijoitteluTulos =>
-        log.info("Caching haun tulos for haku {} with {} jonotietos", tulos.hakuOid, tulos.valintatapajono.size)
         cache + (tulos.hakuOid, tulos)
 
       case Status.Failure(t) =>

--- a/src/test/scala/fi/vm/sade/hakurekisteri/integration/koski/KoskiServiceSpec.scala
+++ b/src/test/scala/fi/vm/sade/hakurekisteri/integration/koski/KoskiServiceSpec.scala
@@ -37,7 +37,7 @@ class KoskiServiceSpec extends FlatSpec with Matchers with MockitoSugar with Dis
   override val jsonDir = "src/test/scala/fi/vm/sade/hakurekisteri/integration/koski/json/"
 
   it should "retry on occasional errors when updating henkilot for haku" in {
-    val params = KoskiSuoritusHakuParams(saveLukio = false, saveAmmatillinen = true)
+    val params = KoskiSuoritusHakuParams(saveLukio = false, saveAmmatillinen = true, retryWaitMillis = 1000)
     val numeros = Range(1, 12345).map(n => s"1.2.3.$n")
     when(endPoint.request(forUrl("http://localhost/koski/api/sure/oids")))
       .thenReturn((200, List(), "[]"), (200, List(), "[]"), (200, List(), "[]"), (200, List(), "[]"), (200, List(), "[]"), (200, List(), "[]"))


### PR DESCRIPTION
Lisätty uudelleenyrityksiä (oletus 3 kpl/batch, 10 sekunnin odotuksen jälkeen) epäonnistuneille koski-tiedonhauille ja niihin liittyville onr-aliaspyynnöille. 
Parannettu yleisesti batcheittain-haun logitusta. Logitetaan myös haun oid, mikäli kyse on jonkin aktiivisen haun tietojen yöllisestä päivityksestä. 