### PR TITLE
Bug 2164 organisaatiot

### DIFF
--- a/src/main/scala/fi/vm/sade/hakurekisteri/integration/organisaatio/OrganisaatioActor.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/integration/organisaatio/OrganisaatioActor.scala
@@ -106,7 +106,9 @@ class HttpOrganisaatioActor(organisaatioClient: VirkailijaRestClient,
       log.error(errorMessage)
       Future.failed(new IllegalArgumentException(errorMessage))
     } else {
-      val organisationWithoutChildren: Future[Option[Organisaatio]] = organisaatioClient.readObject[Organisaatio]("organisaatio-service.organisaatio", tunniste)(200, maxRetries).map(Option(_))
+      val organisationWithoutChildren: Future[Option[Organisaatio]] = organisaatioClient
+        .readObject[Organisaatio]("organisaatio-service.organisaatio", tunniste)(200, maxRetries)
+        .map(Option(_))
         .recoverWith {
         case p: ExecutionException if p.getCause != null && notFound(p.getCause) =>
           log.warning(s"organisaatio not found with tunniste $tunniste")


### PR DESCRIPTION
Jos organisaatiopalvelun rajapinta palauttaa käyttöoikeustarkistukselle 403-statuksisen kutsun, jätetään siihen liittyvä organisaatio huomioimatta käyttöoikeuspäättelyssä. 

Tähän liittyen tehty muutos organisaatiopalveluun, https://github.com/Opetushallitus/organisaatio/pull/149, jonka asentaminen on vaatimuksena tämän toiminnalle.

