### PR TITLE
BUG-2117: Suren näytä tiedot virta-järjestelmästä painike ei toimi

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
     "bower": {
       "version": "1.8.8",
       "resolved": "https://registry.npmjs.org/bower/-/bower-1.8.8.tgz",
-      "integrity": "sha512-1SrJnXnkP9soITHptSO+ahx3QKp3cVzn8poI6ujqc5SeOkg5iqM1pK9H+DSc2OQ8SnO0jC/NG4Ur/UIwy7574A==",
+      "integrity": "sha1-glRL40ozrq5++4vfmQUkeyz/qYU=",
       "dev": true
     },
     "brace-expansion": {

--- a/src/main/resources/webapp/templates/muokkaa-tiedot.html
+++ b/src/main/resources/webapp/templates/muokkaa-tiedot.html
@@ -57,7 +57,7 @@
                 </header>
                 <div class="panel-body">
                 <aside>
-                    <button type="button" class="btn btn-default btn-xs" ng-click="fetchVirtaTiedot()" ng-disabled="!henkilo.hetu || henkilo.virtatiedot">
+                    <button type="button" class="btn btn-default btn-xs" ng-click="fetchVirtaTiedot()" ng-disabled="henkilo.virtatiedot">
                         <span oph-msg="suoritusrekisteri.muokkaa.naytavirtatiedot">Näytä tiedot Virta-järjestelmästä</span>
                         <span class="glyphicon glyphicon-list"></span>
                     </button>
@@ -138,7 +138,7 @@
                         </table>
                     </div>
                     <aside>
-                        <button type="button" class="btn btn-default btn-xs" ng-click="fetchVirtaTiedot()" ng-disabled="!henkilo.hetu">
+                        <button type="button" class="btn btn-default btn-xs" ng-click="fetchVirtaTiedot()">
                             <span oph-msg="suoritusrekisteri.muokkaa.virtatiedotuudelleen">Hae tiedot Virta-järjestelmästä uudelleen</span>
                             <span class="glyphicon glyphicon-list"></span>
                         </button>

--- a/src/main/scala/fi/vm/sade/hakurekisteri/web/integration/virta/VirtaSuoritusResource.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/web/integration/virta/VirtaSuoritusResource.scala
@@ -49,10 +49,10 @@ class VirtaSuoritusResource(virtaActor: VirtaResourceActorRef, hakemusBasedPermi
       override val is =
         if (HetuUtil.toSyntymaAika(hetuOrHenkiloOid).isDefined) {
           oppijaNumeroRekisteri.getByHetu(hetuOrHenkiloOid).flatMap(henkilo => {
-            println(s"Querying with hetu: ${hetuOrHenkiloOid}")
-            println(s"henkilo.oidHenkilo is now: ${henkilo.oidHenkilo}")
             hasAccess(henkilo.oidHenkilo, user).flatMap(access => {
               if (access) {
+                println(s"Querying with hetu: ${hetuOrHenkiloOid}")
+                println(s"henkilo.oidHenkilo is now: ${henkilo.oidHenkilo}")
                 audit.log(au,
                   HenkilonTiedotVirrasta,
                   new Target.Builder().setField("hetu", hetuOrHenkiloOid).build(),
@@ -68,10 +68,10 @@ class VirtaSuoritusResource(virtaActor: VirtaResourceActorRef, hakemusBasedPermi
           // therefore the returned head should be the master henkilo of this henkiloOid
           oppijaNumeroRekisteri.getByOids(Set(hetuOrHenkiloOid)).flatMap(map => {
             val henkilo = map.head._2
-            println(s"Querying with henkilo oid: ${henkilo.oidHenkilo}")
-            println(s"Querying with henkilo hetu: ${henkilo.hetu}")
             hasAccess(henkilo.oidHenkilo, user).flatMap(access => {
               if (access) {
+                println(s"Querying with henkilo oid: ${henkilo.oidHenkilo}")
+                println(s"Querying with henkilo hetu: ${henkilo.hetu}")
                 audit.log(au,
                   HenkilonTiedotVirrasta,
                   new Target.Builder().setField("hetu", hetuOrHenkiloOid).build(),

--- a/src/main/scala/fi/vm/sade/hakurekisteri/web/integration/virta/VirtaSuoritusResource.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/web/integration/virta/VirtaSuoritusResource.scala
@@ -42,13 +42,13 @@ class VirtaSuoritusResource(virtaActor: VirtaResourceActorRef, hakemusBasedPermi
 
   get("/:hetu", operation(query)) {
     val hetuOrHenkiloOid = params("hetu")
-    println(s"hetu: ${hetuOrHenkiloOid}")
     val user = currentUser.getOrElse(throw new UserNotAuthorized("not authorized"))
     val au = security.auditUser
     new AsyncResult() {
       override implicit def timeout: Duration = 30.seconds
       override val is =
         if (HetuUtil.toSyntymaAika(hetuOrHenkiloOid).isDefined) {
+          println(s"Querying with hetu: ${hetuOrHenkiloOid}")
           oppijaNumeroRekisteri.getByHetu(hetuOrHenkiloOid).flatMap(henkilo => {
             hasAccess(henkilo.oidHenkilo, user).flatMap(access => {
               if (access) {
@@ -67,6 +67,7 @@ class VirtaSuoritusResource(virtaActor: VirtaResourceActorRef, hakemusBasedPermi
           // therefore the returned head should be the master henkilo of this henkiloOid
           oppijaNumeroRekisteri.getByOids(Set(hetuOrHenkiloOid)).flatMap(map => {
             val henkilo = map.head._2
+            println(s"Querying with henkilo oid: ${henkilo.oidHenkilo}")
             hasAccess(henkilo.oidHenkilo, user).flatMap(access => {
               if (access) {
                 audit.log(au,

--- a/src/main/scala/fi/vm/sade/hakurekisteri/web/integration/virta/VirtaSuoritusResource.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/web/integration/virta/VirtaSuoritusResource.scala
@@ -48,8 +48,9 @@ class VirtaSuoritusResource(virtaActor: VirtaResourceActorRef, hakemusBasedPermi
       override implicit def timeout: Duration = 30.seconds
       override val is =
         if (HetuUtil.toSyntymaAika(hetuOrHenkiloOid).isDefined) {
-          println(s"Querying with hetu: ${hetuOrHenkiloOid}")
           oppijaNumeroRekisteri.getByHetu(hetuOrHenkiloOid).flatMap(henkilo => {
+            println(s"Querying with hetu: ${hetuOrHenkiloOid}")
+            println(s"henkilo.oidHenkilo is now: ${henkilo.oidHenkilo}")
             hasAccess(henkilo.oidHenkilo, user).flatMap(access => {
               if (access) {
                 audit.log(au,
@@ -74,7 +75,7 @@ class VirtaSuoritusResource(virtaActor: VirtaResourceActorRef, hakemusBasedPermi
                   HenkilonTiedotVirrasta,
                   new Target.Builder().setField("hetu", hetuOrHenkiloOid).build(),
                   new Changes.Builder().build())
-                virtaActor.actor ? VirtaQuery(oppijanumero = henkilo.oidHenkilo, hetu = Some(hetuOrHenkiloOid))
+                virtaActor.actor ? VirtaQuery(oppijanumero = henkilo.oidHenkilo, hetu = Option.empty)
               } else {
                 Future.successful(VirtaResult(hetuOrHenkiloOid))
               }

--- a/src/main/scala/fi/vm/sade/hakurekisteri/web/integration/virta/VirtaSuoritusResource.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/web/integration/virta/VirtaSuoritusResource.scala
@@ -69,13 +69,14 @@ class VirtaSuoritusResource(virtaActor: VirtaResourceActorRef, hakemusBasedPermi
           oppijaNumeroRekisteri.getByOids(Set(hetuOrHenkiloOid)).flatMap(map => {
             val henkilo = map.head._2
             println(s"Querying with henkilo oid: ${henkilo.oidHenkilo}")
+            println(s"Querying with henkilo hetu: ${henkilo.hetu}")
             hasAccess(henkilo.oidHenkilo, user).flatMap(access => {
               if (access) {
                 audit.log(au,
                   HenkilonTiedotVirrasta,
                   new Target.Builder().setField("hetu", hetuOrHenkiloOid).build(),
                   new Changes.Builder().build())
-                virtaActor.actor ? VirtaQuery(oppijanumero = henkilo.oidHenkilo, hetu = Option.empty)
+                virtaActor.actor ? VirtaQuery(oppijanumero = henkilo.oidHenkilo, hetu = henkilo.hetu)
               } else {
                 Future.successful(VirtaResult(hetuOrHenkiloOid))
               }

--- a/src/test/scala/fi/vm/sade/hakurekisteri/rest/VirtaSuoritusResourceSpec.scala
+++ b/src/test/scala/fi/vm/sade/hakurekisteri/rest/VirtaSuoritusResourceSpec.scala
@@ -103,6 +103,13 @@ class VirtaSuoritusResourceSpec extends ScalatraFunSuite with DispatchSupport wi
 
   addServlet(new VirtaSuoritusResource(virtaSuoritusActor, permissionChecker, fakeOppijaNumeroRekisteri), "/*")
 
+  test("should return required fields from Virta for empty response when querying with hetu") {
+    get("/111111-1976") {
+      status should be (200)
+      body should be ("{\"oppijanumero\":\"1.2.4\",\"opiskeluoikeudet\":[],\"tutkinnot\":[],\"suoritukset\":[]}")
+    }
+  }
+
   test("should return required fields from Virta response when querying with hetu") {
     get("/111111-1975") {
       status should be (200)

--- a/src/test/scala/fi/vm/sade/hakurekisteri/rest/VirtaSuoritusResourceSpec.scala
+++ b/src/test/scala/fi/vm/sade/hakurekisteri/rest/VirtaSuoritusResourceSpec.scala
@@ -103,14 +103,6 @@ class VirtaSuoritusResourceSpec extends ScalatraFunSuite with DispatchSupport wi
 
   addServlet(new VirtaSuoritusResource(virtaSuoritusActor, permissionChecker, fakeOppijaNumeroRekisteri), "/*")
 
-
-  test("should return required fields from Virta for empty response") {
-    get("/1.2.4") {
-      status should be (200)
-      body should be ("{\"oppijanumero\":\"1.2.4\",\"opiskeluoikeudet\":[],\"tutkinnot\":[],\"suoritukset\":[]}")
-    }
-  }
-
   test("should return required fields from Virta response when querying with hetu") {
     get("/111111-1975") {
       status should be (200)

--- a/src/test/scala/fi/vm/sade/hakurekisteri/rest/VirtaSuoritusResourceSpec.scala
+++ b/src/test/scala/fi/vm/sade/hakurekisteri/rest/VirtaSuoritusResourceSpec.scala
@@ -28,6 +28,7 @@ class VirtaSuoritusResourceSpec extends ScalatraFunSuite with DispatchSupport wi
   val endPoint = mock[Endpoint]
 
   when(endPoint.request(forUrl("http://virtawstesti.csc.fi/luku/OpiskelijanTiedot").withBodyPart("1.2.4"))).thenReturn((200, List(), VirtaResults.emptyResp))
+  when(endPoint.request(forUrl("http://virtawstesti.csc.fi/luku/OpiskelijanTiedot").withBodyPart("111111-1976"))).thenReturn((200, List(), VirtaResults.emptyResp))
   when(endPoint.request(forUrl("http://virtawstesti.csc.fi/luku/OpiskelijanTiedot").withBodyPart("1.2.5"))).thenReturn((500, List(), "Internal Server Error"))
   when(endPoint.request(forUrl("http://virtawstesti.csc.fi/luku/OpiskelijanTiedot").withBodyPart("1.3.0"))).thenReturn((200, List(), VirtaResults.multipleStudents))
   when(endPoint.request(forUrl("http://virtawstesti.csc.fi/luku/OpiskelijanTiedot").withBodyPart("1.5.0"))).thenReturn((500, List(), VirtaResults.fault))
@@ -50,22 +51,53 @@ class VirtaSuoritusResourceSpec extends ScalatraFunSuite with DispatchSupport wi
       throw new UnsupportedOperationException("Not implemented")
     }
     override def getByHetu(hetu: String): Future[Henkilo] = {
-      Future.successful(Henkilo(
-        oidHenkilo = "1.2.4",
-        hetu = Some("111111-1975"),
-        henkiloTyyppi = "OPPIJA",
-        etunimet = None,
-        kutsumanimi = None,
-        sukunimi = None,
-        aidinkieli = None,
-        kansalaisuus = List.empty,
-        syntymaaika = None,
-        sukupuoli = None,
-        turvakielto = Some(false)
-      ))
+      if (hetu.equals("111111-1975")) {
+        Future.successful(Henkilo(
+          oidHenkilo = "1.2.4",
+          hetu = Some("111111-1975"),
+          henkiloTyyppi = "OPPIJA",
+          etunimet = None,
+          kutsumanimi = None,
+          sukunimi = None,
+          aidinkieli = None,
+          kansalaisuus = List.empty,
+          syntymaaika = None,
+          sukupuoli = None,
+          turvakielto = Some(false)
+        ))
+      } else {
+        Future.successful(Henkilo(
+          oidHenkilo = "1.2.4",
+          hetu = Some("111111-1976"),
+          henkiloTyyppi = "OPPIJA",
+          etunimet = None,
+          kutsumanimi = None,
+          sukunimi = None,
+          aidinkieli = None,
+          kansalaisuus = List.empty,
+          syntymaaika = None,
+          sukupuoli = None,
+          turvakielto = Some(false)
+        ))
+      }
     }
 
-    override def getByOids(oids: Set[String]): Future[Map[String, Henkilo]] = Future.successful(Map.empty)
+    override def getByOids(oids: Set[String]): Future[Map[String, Henkilo]] = Future.successful(Map(
+      ("1.2.3",
+        Henkilo(
+          oidHenkilo = "1.2.3",
+          hetu = Some("111111-1975"),
+          henkiloTyyppi = "OPPIJA",
+          etunimet = None,
+          kutsumanimi = None,
+          sukunimi = None,
+          aidinkieli = None,
+          kansalaisuus = List.empty,
+          syntymaaika = None,
+          sukupuoli = None,
+          turvakielto = Some(false))
+      )
+    ))
   }
 
 
@@ -76,6 +108,13 @@ class VirtaSuoritusResourceSpec extends ScalatraFunSuite with DispatchSupport wi
     get("/1.2.4") {
       status should be (200)
       body should be ("{\"oppijanumero\":\"1.2.4\",\"opiskeluoikeudet\":[],\"tutkinnot\":[],\"suoritukset\":[]}")
+    }
+  }
+
+  test("should return required fields from Virta response when querying with hetu") {
+    get("/111111-1975") {
+      status should be (200)
+      body should include ("875101")
     }
   }
 


### PR DESCRIPTION
Nyt suoritustietojen haku virrasta tapahtuu ensisijassa henkilön hetulla, mikäli sellainen on määritelty requestiin. Muussa tapauksessa (duplikaattihenkilö) kysytään ensin ONR:ltä master-henkilö, jolla suoritustiedot voidaan hakea duplikaatille.