### PR TITLE
OY-4208 & OY-4212 7-8-valmistava filtering fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,7 @@ db/schema.ddl
 
 suoritusrekisteri-it-db
 src/main/webapp/
+
+.bsp/
+.vscode/
+project/

--- a/src/main/scala/fi/vm/sade/hakurekisteri/integration/koski/KoskiDataHandler.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/integration/koski/KoskiDataHandler.scala
@@ -16,7 +16,7 @@ import org.slf4j.LoggerFactory
 
 import java.util.UUID
 import scala.concurrent.duration._
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{Await, ExecutionContext, Future}
 
 case class SuoritusArvosanat(
   suoritus: VirallinenSuoritus,
@@ -573,7 +573,7 @@ class KoskiDataHandler(
     viimeisimmatSuoritukset: Seq[SuoritusArvosanat],
     personOidsWithAliases: PersonOidsWithAliases,
     params: KoskiSuoritusHakuParams
-  ): Future[Seq[Either[Exception, Option[SuoritusArvosanat]]]] = {
+  ): Future[Seq[Either[Exception, Option[SuoritusArvosanat]]]] =
     fetchExistingSuoritukset(henkiloOid, personOidsWithAliases).flatMap(fetchedSuoritukset => {
       //OY-227 : Check and delete if there is suoritus which is not included on new suoritukset.
       var tallennettavatSuoritukset = viimeisimmatSuoritukset
@@ -612,7 +612,7 @@ class KoskiDataHandler(
           henkilo
         )
       ) {
-        updateOppilaitosSeiskaKasiJaValmistava(koskiHenkiloContainer)
+        Await.result(updateOppilaitosSeiskaKasiJaValmistava(koskiHenkiloContainer), 5.seconds)
       }
 
       val suorituksetForRemoving = tallennettavatSuoritukset
@@ -690,7 +690,6 @@ class KoskiDataHandler(
         })
       )
     })
-  }
 
   def createSuorituksetJaArvosanatFromKoski(
     henkilo: KoskiHenkiloContainer

--- a/src/main/scala/fi/vm/sade/hakurekisteri/integration/koski/KoskiDataHandler.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/integration/koski/KoskiDataHandler.scala
@@ -782,6 +782,7 @@ class KoskiDataHandler(
     koskihenkilöcontainer.opiskeluoikeudet
       .filter(
         _.tila.opiskeluoikeusjaksot
+          .filter(jakso => LocalDate.parse(jakso.alku).compareTo(LocalDate.now()) <= 0)
           .sortBy(jakso => LocalDate.parse(jakso.alku))(Ordering[LocalDate].reverse)
           .head
           .tila

--- a/src/test/scala/fi/vm/sade/hakurekisteri/integration/koski/KoskiDataHandlerTest.scala
+++ b/src/test/scala/fi/vm/sade/hakurekisteri/integration/koski/KoskiDataHandlerTest.scala
@@ -2090,7 +2090,47 @@ class KoskiDataHandlerTest
     suoritus.size should equal(0)
   }
 
-  it should "store seiskaKasiJaValmentava with present study status, even when there is a future absent study status" in {
+  it should "store opiskelija in seiskaKasiJaValmentava case even with perusopetus unfinished" in {
+    val json: String =
+      scala.io.Source
+        .fromFile(jsonDir + "koskidata_7_8_valmistava_ei_peruskoulun_paattanyt.json")
+        .mkString
+
+    val koskiHenkilo: KoskiHenkiloContainer = parse(json).extract[KoskiHenkiloContainer]
+    koskiHenkilo should not be null
+    val henkiloOid: String = koskiHenkilo.henkilö.oid.toString
+    koskiHenkilo.opiskeluoikeudet.head.tyyppi should not be empty
+    val alaikainenOnrHenkilo: Henkilo =
+      generateTestONRHenkilo(koskiHenkilo, LocalDate.now().minusYears(15).toString())
+
+    Await.result(
+      koskiDatahandler.processHenkilonTiedotKoskesta(
+        koskiHenkilo,
+        PersonOidsWithAliases(koskiHenkilo.henkilö.oid.toSet),
+        new KoskiSuoritusHakuParams(
+          saveLukio = false,
+          saveAmmatillinen = false,
+          saveSeiskaKasiJaValmistava = true
+        ),
+        Option(alaikainenOnrHenkilo)
+      ),
+      5.seconds
+    )
+
+    val opiskelijat = run(database.run(sql"select henkilo_oid from opiskelija".as[String]))
+    opiskelijat.size should equal(1)
+    val oppilaitos = run(database.run(sql"select oppilaitos_oid from opiskelija".as[String]))
+    oppilaitos.head should not be empty
+    oppilaitos.head should equal("1.2.246.562.10.64818893022")
+    val suoritus = run(
+      database.run(
+        sql"select valmistuminen from suoritus where henkilo_oid = $henkiloOid".as[String]
+      )
+    )
+    suoritus.size should equal(0)
+  }
+
+  it should "ignore future absent study status when storing opiskelija in seiskaKasiJaValmentava case" in {
     val json: String =
       scala.io.Source
         .fromFile(jsonDir + "koskidata_7_8_tuleva_ei_lasna.json")

--- a/src/test/scala/fi/vm/sade/hakurekisteri/integration/koski/json/koskidata_7_8_tuleva_ei_lasna.json
+++ b/src/test/scala/fi/vm/sade/hakurekisteri/integration/koski/json/koskidata_7_8_tuleva_ei_lasna.json
@@ -1,0 +1,254 @@
+{
+  "henkilö" : {
+    "oid" : "1.2.246.562.24.98783827965",
+    "hetu" : "051287-971N",
+    "syntymäaika" : "1987-12-05",
+    "etunimet" : "Titus Testi",
+    "kutsumanimi" : "Titus",
+    "sukunimi" : "Antikainen-Testi",
+    "äidinkieli" : {
+      "koodiarvo" : "FI",
+      "nimi" : {
+        "fi" : "suomi",
+        "sv" : "finska",
+        "en" : "Finnish"
+      },
+      "lyhytNimi" : {
+        "fi" : "suomi",
+        "sv" : "finska",
+        "en" : "Finnish"
+      },
+      "koodistoUri" : "kieli",
+      "koodistoVersio" : 1
+    },
+    "kansalaisuus" : [ {
+      "koodiarvo" : "246",
+      "nimi" : {
+        "fi" : "Suomi",
+        "sv" : "Finland",
+        "en" : "Finland"
+      },
+      "lyhytNimi" : {
+        "fi" : "FI",
+        "sv" : "FI",
+        "en" : "FI"
+      },
+      "koodistoUri" : "maatjavaltiot2",
+      "koodistoVersio" : 2
+    } ],
+    "turvakielto" : false
+  },
+  "opiskeluoikeudet" : [ {
+    "oid": "1.2.246.562.15.98195003417",
+    "versionumero": 9,
+    "aikaleima": "2019-01-22T10:29:45.231135",
+    "oppilaitos": {
+      "oid": "1.2.246.562.10.64818893022",
+      "oppilaitosnumero": {
+        "koodiarvo": "05195",
+        "nimi": {
+          "fi": "Teppanan koulu"
+        },
+        "lyhytNimi": {
+          "fi": "Teppanan koulu"
+        },
+        "koodistoUri": "oppilaitosnumero",
+        "koodistoVersio": 1
+      },
+      "nimi": {
+        "fi": "Teppanan koulu"
+      },
+      "kotipaikka": {
+        "koodiarvo": "205",
+        "nimi": {
+          "fi": "Kajaani",
+          "sv": "Kajana"
+        },
+        "koodistoUri": "kunta",
+        "koodistoVersio": 2
+      }
+    },
+    "koulutustoimija": {
+      "oid": "1.2.246.562.10.67019405611",
+      "nimi": {
+        "fi": "Kajaanin kaupunki"
+      },
+      "yTunnus": "0214958-9",
+      "kotipaikka": {
+        "koodiarvo": "205",
+        "nimi": {
+          "fi": "Kajaani",
+          "sv": "Kajana"
+        },
+        "koodistoUri": "kunta",
+        "koodistoVersio": 2
+      }
+    },
+    "tila" : {
+      "opiskeluoikeusjaksot" : [ {
+        "alku" : "2022-10-21",
+        "tila" : {
+          "koodiarvo" : "lasna",
+          "nimi" : {
+            "fi" : "Läsnä",
+            "sv" : "Närvarande",
+            "en" : "Present"
+          },
+          "koodistoUri" : "koskiopiskeluoikeudentila",
+          "koodistoVersio" : 1
+        }
+      }, {
+        "alku" : "2022-11-23",
+        "tila" : {
+          "koodiarvo" : "loma",
+          "nimi" : {
+            "fi" : "Loma",
+            "sv" : "Semester",
+            "en" : "Vacation"
+          },
+          "koodistoUri" : "koskiopiskeluoikeudentila",
+          "koodistoVersio" : 1
+        }
+      }, {
+        "alku" : "2023-01-09",
+        "tila" : {
+          "koodiarvo" : "lasna",
+          "nimi" : {
+            "fi" : "Läsnä",
+            "sv" : "Närvarande",
+            "en" : "Present"
+          },
+          "koodistoUri" : "koskiopiskeluoikeudentila",
+          "koodistoVersio" : 1
+        }
+      }, {
+        "alku" : "2023-02-20",
+        "tila" : {
+          "koodiarvo" : "loma",
+          "nimi" : {
+            "fi" : "Loma",
+            "sv" : "Semester",
+            "en" : "Vacation"
+          },
+          "koodistoUri" : "koskiopiskeluoikeudentila",
+          "koodistoVersio" : 1
+        }
+      }, {
+        "alku" : "2023-02-25",
+        "tila" : {
+          "koodiarvo" : "lasna",
+          "nimi" : {
+            "fi" : "Läsnä",
+            "sv" : "Närvarande",
+            "en" : "Present"
+          },
+          "koodistoUri" : "koskiopiskeluoikeudentila",
+          "koodistoVersio" : 1
+        }
+      }, {
+        "alku" : "XXXX-XX-XX",
+        "tila" : {
+          "koodiarvo" : "loma",
+          "nimi" : {
+            "fi" : "Loma",
+            "sv" : "Semester",
+            "en" : "Vacation"
+          },
+          "koodistoUri" : "koskiopiskeluoikeudentila",
+          "koodistoVersio" : 1
+        }
+      } ]
+    },
+    "suoritukset" : [ {
+      "koulutusmoduuli" : {
+        "tunniste" : {
+          "koodiarvo" : "999905",
+          "nimi" : {
+            "fi" : "Perusopetukseen valmistava opetus",
+            "sv" : "Undervisning som förebereder för den grundläggande utbildning"
+          },
+          "lyhytNimi" : {
+            "fi" : "Perusopetukseen valmistava opetus"
+          },
+          "koodistoUri" : "koulutus",
+          "koodistoVersio" : 12
+        },
+        "perusteenDiaarinumero" : "57/011/2015",
+        "koulutustyyppi" : {
+          "koodiarvo" : "22",
+          "nimi" : {
+            "fi" : "Perusopetukseen valmistava opetus",
+            "sv" : "Utbildning som förbereder för grundläggande utbildning"
+          },
+          "koodistoUri" : "koulutustyyppi"
+        }
+      },
+      "toimipiste": {
+        "oid": "1.2.246.562.10.64818893022",
+        "oppilaitosnumero": {
+          "koodiarvo": "05195",
+          "nimi": {
+            "fi": "Teppanan koulu"
+          },
+          "lyhytNimi": {
+            "fi": "Teppanan koulu"
+          },
+          "koodistoUri": "oppilaitosnumero",
+          "koodistoVersio": 1
+        },
+        "nimi": {
+          "fi": "Teppanan koulu"
+        },
+        "kotipaikka": {
+          "koodiarvo": "205",
+          "nimi": {
+            "fi": "Kajaani",
+            "sv": "Kajana"
+          },
+          "koodistoUri": "kunta",
+          "koodistoVersio": 2
+        }
+      },
+      "suorituskieli" : {
+        "koodiarvo" : "FI",
+        "nimi" : {
+          "fi" : "suomi",
+          "sv" : "finska",
+          "en" : "Finnish"
+        },
+        "lyhytNimi" : {
+          "fi" : "suomi",
+          "sv" : "finska",
+          "en" : "Finnish"
+        },
+        "koodistoUri" : "kieli",
+        "koodistoVersio" : 1
+      },
+      "osasuoritukset" : [ ],
+      "tyyppi" : {
+        "koodiarvo" : "perusopetukseenvalmistavaopetus",
+        "nimi" : {
+          "fi" : "Perusopetukseen valmistava opetus",
+          "sv" : "Förberedande undervisning för grundläggande utbildning",
+          "en" : "Instruction preparing for basic education"
+        },
+        "koodistoUri" : "suorituksentyyppi",
+        "koodistoVersio" : 1
+      }
+    } ],
+    "tyyppi" : {
+      "koodiarvo" : "perusopetukseenvalmistavaopetus",
+      "nimi" : {
+        "fi" : "Perusopetukseen valmistava opetus",
+        "sv" : "Förberedande undervisning för den grundläggande utbildningen",
+        "en" : "Instruction preparing for basic education"
+      },
+      "lyhytNimi" : {
+        "fi" : "Perusopetukseen valmistava opetus"
+      },
+      "koodistoUri" : "opiskeluoikeudentyyppi",
+      "koodistoVersio" : 1
+    },
+    "alkamispäivä" : "2022-11-21"
+  } ]
+}

--- a/src/test/scala/fi/vm/sade/hakurekisteri/integration/koski/json/koskidata_7_8_valmistava_ei_peruskoulun_paattanyt.json
+++ b/src/test/scala/fi/vm/sade/hakurekisteri/integration/koski/json/koskidata_7_8_valmistava_ei_peruskoulun_paattanyt.json
@@ -1,0 +1,462 @@
+{
+  "henkilö" : {
+    "oid" : "1.2.246.562.24.98783827965",
+    "hetu" : "051287-971N",
+    "syntymäaika" : "1987-12-05",
+    "etunimet" : "Titus Testi",
+    "kutsumanimi" : "Titus",
+    "sukunimi" : "Antikainen-Testi",
+    "äidinkieli" : {
+      "koodiarvo" : "FI",
+      "nimi" : {
+        "fi" : "suomi",
+        "sv" : "finska",
+        "en" : "Finnish"
+      },
+      "lyhytNimi" : {
+        "fi" : "suomi",
+        "sv" : "finska",
+        "en" : "Finnish"
+      },
+      "koodistoUri" : "kieli",
+      "koodistoVersio" : 1
+    },
+    "kansalaisuus" : [ {
+      "koodiarvo" : "246",
+      "nimi" : {
+        "fi" : "Suomi",
+        "sv" : "Finland",
+        "en" : "Finland"
+      },
+      "lyhytNimi" : {
+        "fi" : "FI",
+        "sv" : "FI",
+        "en" : "FI"
+      },
+      "koodistoUri" : "maatjavaltiot2",
+      "koodistoVersio" : 2
+    } ],
+    "turvakielto" : false
+  },
+  "opiskeluoikeudet" : [ {
+    "oid": "1.2.246.562.15.98195003417",
+    "versionumero": 9,
+    "aikaleima": "2019-01-22T10:29:45.231135",
+    "oppilaitos": {
+      "oid": "1.2.246.562.10.64818893022",
+      "oppilaitosnumero": {
+        "koodiarvo": "05195",
+        "nimi": {
+          "fi": "Teppanan koulu"
+        },
+        "lyhytNimi": {
+          "fi": "Teppanan koulu"
+        },
+        "koodistoUri": "oppilaitosnumero",
+        "koodistoVersio": 1
+      },
+      "nimi": {
+        "fi": "Teppanan koulu"
+      },
+      "kotipaikka": {
+        "koodiarvo": "205",
+        "nimi": {
+          "fi": "Kajaani",
+          "sv": "Kajana"
+        },
+        "koodistoUri": "kunta",
+        "koodistoVersio": 2
+      }
+    },
+    "koulutustoimija": {
+      "oid": "1.2.246.562.10.67019405611",
+      "nimi": {
+        "fi": "Kajaanin kaupunki"
+      },
+      "yTunnus": "0214958-9",
+      "kotipaikka": {
+        "koodiarvo": "205",
+        "nimi": {
+          "fi": "Kajaani",
+          "sv": "Kajana"
+        },
+        "koodistoUri": "kunta",
+        "koodistoVersio": 2
+      }
+    },
+    "tila" : {
+      "opiskeluoikeusjaksot" : [ {
+        "alku" : "2022-07-11",
+        "tila" : {
+          "koodiarvo" : "lasna",
+          "nimi" : {
+            "fi" : "Läsnä",
+            "sv" : "Närvarande",
+            "en" : "Present"
+          },
+          "koodistoUri" : "koskiopiskeluoikeudentila",
+          "koodistoVersio" : 1
+        }
+      }, {
+        "alku" : "2022-10-21",
+        "tila" : {
+          "koodiarvo" : "loma",
+          "nimi" : {
+            "fi" : "Loma",
+            "sv" : "Semester",
+            "en" : "Vacation"
+          },
+          "koodistoUri" : "koskiopiskeluoikeudentila",
+          "koodistoVersio" : 1
+        }
+      }, {
+        "alku" : "2022-10-27",
+        "tila" : {
+          "koodiarvo" : "lasna",
+          "nimi" : {
+            "fi" : "Läsnä",
+            "sv" : "Närvarande",
+            "en" : "Present"
+          },
+          "koodistoUri" : "koskiopiskeluoikeudentila",
+          "koodistoVersio" : 1
+        }
+      }, {
+        "alku" : "2022-12-21",
+        "tila" : {
+          "koodiarvo" : "loma",
+          "nimi" : {
+            "fi" : "Loma",
+            "sv" : "Semester",
+            "en" : "Vacation"
+          },
+          "koodistoUri" : "koskiopiskeluoikeudentila",
+          "koodistoVersio" : 1
+        }
+      }, {
+        "alku" : "2023-01-12",
+        "tila" : {
+          "koodiarvo" : "lasna",
+          "nimi" : {
+            "fi" : "Läsnä",
+            "sv" : "Närvarande",
+            "en" : "Present"
+          },
+          "koodistoUri" : "koskiopiskeluoikeudentila",
+          "koodistoVersio" : 1
+        }
+      }, {
+        "alku" : "2023-02-23",
+        "tila" : {
+          "koodiarvo" : "loma",
+          "nimi" : {
+            "fi" : "Loma",
+            "sv" : "Semester",
+            "en" : "Vacation"
+          },
+          "koodistoUri" : "koskiopiskeluoikeudentila",
+          "koodistoVersio" : 1
+        }
+      }, {
+        "alku" : "2023-02-25",
+        "tila" : {
+          "koodiarvo" : "lasna",
+          "nimi" : {
+            "fi" : "Läsnä",
+            "sv" : "Närvarande",
+            "en" : "Present"
+          },
+          "koodistoUri" : "koskiopiskeluoikeudentila",
+          "koodistoVersio" : 1
+        }
+      } ]
+    },
+    "suoritukset" : [ {
+      "koulutusmoduuli" : {
+        "tunniste" : {
+          "koodiarvo" : "999905",
+          "nimi" : {
+            "fi" : "Perusopetukseen valmistava opetus",
+            "sv" : "Undervisning som förebereder för den grundläggande utbildning"
+          },
+          "lyhytNimi" : {
+            "fi" : "Perusopetukseen valmistava opetus"
+          },
+          "koodistoUri" : "koulutus",
+          "koodistoVersio" : 12
+        },
+        "perusteenDiaarinumero" : "57/011/2015",
+        "koulutustyyppi" : {
+          "koodiarvo" : "22",
+          "nimi" : {
+            "fi" : "Perusopetukseen valmistava opetus",
+            "sv" : "Utbildning som förbereder för grundläggande utbildning"
+          },
+          "koodistoUri" : "koulutustyyppi"
+        }
+      },
+      "toimipiste": {
+        "oid": "1.2.246.562.10.64818893022",
+        "oppilaitosnumero": {
+          "koodiarvo": "05195",
+          "nimi": {
+            "fi": "Teppanan koulu"
+          },
+          "lyhytNimi": {
+            "fi": "Teppanan koulu"
+          },
+          "koodistoUri": "oppilaitosnumero",
+          "koodistoVersio": 1
+        },
+        "nimi": {
+          "fi": "Teppanan koulu"
+        },
+        "kotipaikka": {
+          "koodiarvo": "205",
+          "nimi": {
+            "fi": "Kajaani",
+            "sv": "Kajana"
+          },
+          "koodistoUri": "kunta",
+          "koodistoVersio": 2
+        }
+      },
+      "suorituskieli" : {
+        "koodiarvo" : "FI",
+        "nimi" : {
+          "fi" : "suomi",
+          "sv" : "finska",
+          "en" : "Finnish"
+        },
+        "lyhytNimi" : {
+          "fi" : "suomi",
+          "sv" : "finska",
+          "en" : "Finnish"
+        },
+        "koodistoUri" : "kieli",
+        "koodistoVersio" : 1
+      },
+      "osasuoritukset" : [ ],
+      "tyyppi" : {
+        "koodiarvo" : "perusopetukseenvalmistavaopetus",
+        "nimi" : {
+          "fi" : "Perusopetukseen valmistava opetus",
+          "sv" : "Förberedande undervisning för grundläggande utbildning",
+          "en" : "Instruction preparing for basic education"
+        },
+        "koodistoUri" : "suorituksentyyppi",
+        "koodistoVersio" : 1
+      }
+    } ],
+    "tyyppi" : {
+      "koodiarvo" : "perusopetukseenvalmistavaopetus",
+      "nimi" : {
+        "fi" : "Perusopetukseen valmistava opetus",
+        "sv" : "Förberedande undervisning för den grundläggande utbildningen",
+        "en" : "Instruction preparing for basic education"
+      },
+      "lyhytNimi" : {
+        "fi" : "Perusopetukseen valmistava opetus"
+      },
+      "koodistoUri" : "opiskeluoikeudentyyppi",
+      "koodistoVersio" : 1
+    },
+    "alkamispäivä" : "2022-08-11"
+  }, {
+    "oid" : "1.2.246.562.15.98195003417",
+    "versionumero" : 2,
+    "aikaleima" : "2022-06-24T13:31:55.917835",
+    "lähdejärjestelmänId" : {
+      "id" : "665559",
+      "lähdejärjestelmä" : {
+        "koodiarvo" : "primus",
+        "nimi" : {
+          "fi" : "primus"
+        },
+        "koodistoUri" : "lahdejarjestelma",
+        "koodistoVersio" : 1
+      }
+    },
+    "oppilaitos" : {
+      "oid" : "1.2.246.562.10.81017043621",
+      "oppilaitosnumero" : {
+        "koodiarvo" : "00551",
+        "nimi" : {
+          "fi" : "Helsingin aikuislukio",
+          "sv" : "Helsingin aikuislukio",
+          "en" : "Helsingin aikuislukio"
+        },
+        "lyhytNimi" : {
+          "fi" : "Helsingin aikuislukio",
+          "sv" : "Helsingin aikuislukio",
+          "en" : "Helsingin aikuislukio"
+        },
+        "koodistoUri" : "oppilaitosnumero",
+        "koodistoVersio" : 1
+      },
+      "nimi" : {
+        "fi" : "Helsingin aikuislukio",
+        "sv" : "Helsingin aikuislukio",
+        "en" : "Helsingin aikuislukio"
+      },
+      "kotipaikka" : {
+        "koodiarvo" : "091",
+        "nimi" : {
+          "fi" : "Helsinki",
+          "sv" : "Helsingfors"
+        },
+        "koodistoUri" : "kunta",
+        "koodistoVersio" : 2
+      }
+    },
+    "koulutustoimija" : {
+      "oid" : "1.2.246.562.10.346830761110",
+      "nimi" : {
+        "fi" : "Helsingin kaupunki",
+        "sv" : "Helsingfors stad",
+        "en" : "Helsingin kaupunki"
+      },
+      "yTunnus" : "0201256-6",
+      "kotipaikka" : {
+        "koodiarvo" : "091",
+        "nimi" : {
+          "fi" : "Helsinki",
+          "sv" : "Helsingfors"
+        },
+        "koodistoUri" : "kunta",
+        "koodistoVersio" : 2
+      }
+    },
+    "tila" : {
+      "opiskeluoikeusjaksot" : [ {
+        "alku" : "2022-06-08",
+        "tila" : {
+          "koodiarvo" : "lasna",
+          "nimi" : {
+            "fi" : "Läsnä",
+            "sv" : "Närvarande",
+            "en" : "Present"
+          },
+          "koodistoUri" : "koskiopiskeluoikeudentila",
+          "koodistoVersio" : 1
+        },
+        "opintojenRahoitus" : {
+          "koodiarvo" : "1",
+          "nimi" : {
+            "fi" : "Valtionosuusrahoitteinen koulutus",
+            "sv" : "Statsandelsfinansierad utbildning"
+          },
+          "koodistoUri" : "opintojenrahoitus",
+          "koodistoVersio" : 1
+        }
+      }, {
+        "alku" : "2022-06-25",
+        "tila" : {
+          "koodiarvo" : "eronnut",
+          "nimi" : {
+            "fi" : "Eronnut",
+            "sv" : "Utskriven",
+            "en" : "Discontinued"
+          },
+          "koodistoUri" : "koskiopiskeluoikeudentila",
+          "koodistoVersio" : 1
+        }
+      } ]
+    },
+    "lisätiedot" : { },
+    "suoritukset" : [ {
+      "koulutusmoduuli" : {
+        "tunniste" : {
+          "koodiarvo" : "XX",
+          "nimi" : {
+            "fi" : "Ei tiedossa",
+            "sv" : "Okänd",
+            "en" : "Unknown"
+          },
+          "koodistoUri" : "koskioppiaineetyleissivistava",
+          "koodistoVersio" : 1
+        }
+      },
+      "toimipiste" : {
+        "oid" : "1.2.246.562.10.81017043621",
+        "oppilaitosnumero" : {
+          "koodiarvo" : "00551",
+          "nimi" : {
+            "fi" : "Helsingin aikuislukio",
+            "sv" : "Helsingin aikuislukio",
+            "en" : "Helsingin aikuislukio"
+          },
+          "lyhytNimi" : {
+            "fi" : "Helsingin aikuislukio",
+            "sv" : "Helsingin aikuislukio",
+            "en" : "Helsingin aikuislukio"
+          },
+          "koodistoUri" : "oppilaitosnumero",
+          "koodistoVersio" : 1
+        },
+        "nimi" : {
+          "fi" : "Helsingin aikuislukio",
+          "sv" : "Helsingin aikuislukio",
+          "en" : "Helsingin aikuislukio"
+        },
+        "kotipaikka" : {
+          "koodiarvo" : "091",
+          "nimi" : {
+            "fi" : "Helsinki",
+            "sv" : "Helsingfors"
+          },
+          "koodistoUri" : "kunta",
+          "koodistoVersio" : 2
+        }
+      },
+      "suoritustapa" : {
+        "koodiarvo" : "koulutus",
+        "nimi" : {
+          "fi" : "Koulutus",
+          "sv" : "Utbildning"
+        },
+        "koodistoUri" : "perusopetuksensuoritustapa",
+        "koodistoVersio" : 1
+      },
+      "suorituskieli" : {
+        "koodiarvo" : "FI",
+        "nimi" : {
+          "fi" : "suomi",
+          "sv" : "finska",
+          "en" : "Finnish"
+        },
+        "lyhytNimi" : {
+          "fi" : "suomi",
+          "sv" : "finska",
+          "en" : "Finnish"
+        },
+        "koodistoUri" : "kieli",
+        "koodistoVersio" : 1
+      },
+      "tyyppi" : {
+        "koodiarvo" : "perusopetuksenoppiaineenoppimaara",
+        "nimi" : {
+          "fi" : "Perusopetuksen oppiaineen oppimäärä",
+          "sv" : "Lärokurs i ett läroämne i grundläggande utbildning",
+          "en" : "Basic education Subject syllabus"
+        },
+        "koodistoUri" : "suorituksentyyppi",
+        "koodistoVersio" : 1
+      }
+    } ],
+    "tyyppi" : {
+      "koodiarvo" : "aikuistenperusopetus",
+      "nimi" : {
+        "fi" : "Aikuisten perusopetus",
+        "sv" : "Grundläggande utbildning för vuxna"
+      },
+      "lyhytNimi" : {
+        "fi" : "Aikuisten perusopetus"
+      },
+      "koodistoUri" : "opiskeluoikeudentyyppi",
+      "koodistoVersio" : 1
+    },
+    "alkamispäivä" : "2022-06-08",
+    "päättymispäivä" : "2022-06-25"
+  } ]
+}


### PR DESCRIPTION
Fixes:
- OY-4208: filtering order was incorrect, so that perusopetuksen oppiaineen suoritus without finished perusopetuksen suoritus blocked saving 7-8-valmistava data
- OY-4212: future absences were incorrectly considered in determining saving of 7-8-valmistava data