### PR TITLE
OY-4267 Drop johtaaTutkintoon from old APIs

### DIFF
--- a/src/main/scala/fi/vm/sade/hakurekisteri/web/kkhakija/KkHakijaService.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/web/kkhakija/KkHakijaService.scala
@@ -1047,7 +1047,7 @@ class KkHakijaService(
                   kkKoulutusId = koulutus.kkKoulutusId,
                   koulutuksenAlkamiskausi = None,
                   koulutuksenAlkamisvuosi = None,
-                  johtaaTutkintoon = koulutus.johtaaTutkintoon
+                  johtaaTutkintoon = None
                 )
               ),
             liitteet = attachmentToLiite(hakemus.attachmentRequests)
@@ -1125,7 +1125,7 @@ class KkHakijaService(
                     kkKoulutusId = koulutus.kkKoulutusId,
                     koulutuksenAlkamiskausi = None,
                     koulutuksenAlkamisvuosi = None,
-                    johtaaTutkintoon = koulutus.johtaaTutkintoon
+                    johtaaTutkintoon = None
                   )
                 ),
               liitteet = None


### PR DESCRIPTION
For some reason new kkhakijat v5 field hakemukset->hakukohteenKoulutukset->johtaaTutkintoon was accidentally added to v1-v4 responses, causing validation errors on external clients. Return it only with v5 responses.