### PR TITLE
OY-4780 restore discarding <30 osp VALMA even when ready

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,7 @@ db/schema.ddl
 .bsp/
 .vscode/
 project/
+.metals/
 
 suoritusrekisteri-it-db
 src/main/webapp/

--- a/src/main/scala/fi/vm/sade/hakurekisteri/integration/koski/KoskiDataHandler.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/integration/koski/KoskiDataHandler.scala
@@ -108,11 +108,11 @@ class KoskiDataHandler(
       suoritus.tyyppi.exists(_.koodiarvo == "valma")
       && !suoritus.laajuusVahintaan(30)
       && opiskeluoikeus.tila.opiskeluoikeusjaksot
-        .exists(ooj => KoskiUtil.eronneeseenRinnastettavatKoskiTilat.contains(ooj.tila.koodiarvo))
+        .exists(ooj => KoskiUtil.eiHalututAlle30opValmaTilat.contains(ooj.tila.koodiarvo))
     ) {
       logger.info(
         s"Filtteröitiin henkilöltä $henkiloOid valma-suoritus, joka sisälsi alle 30 osp ja " +
-          s"kuului eronneeseen rinnastettaviin tiloihin."
+          s"kuului eronneeseen rinnastettaviin tiloihin tai oli valmis."
       )
       return false
     }

--- a/src/main/scala/fi/vm/sade/hakurekisteri/integration/koski/KoskiUtil.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/integration/koski/KoskiUtil.scala
@@ -101,8 +101,8 @@ object KoskiUtil {
 
   val AIKUISTENPERUS_LUOKKAASTE = "AIK"
 
-  val eiHalututAlle30opValmaTilat: Seq[String] =
-    Seq("eronnut", "erotettu", "katsotaaneronneeksi", "mitatoity", "peruutettu", "valmistunut")
+  val eiHalututAlle30opValmaTilat =
+    Set("eronnut", "erotettu", "katsotaaneronneeksi", "mitatoity", "peruutettu", "valmistunut")
 
   val eronneeseenRinnastettavatKoskiTilat =
     Set("eronnut", "erotettu", "katsotaaneronneeksi", "mitatoity", "peruutettu")

--- a/src/test/scala/fi/vm/sade/hakurekisteri/integration/koski/KoskiDataHandlerTest.scala
+++ b/src/test/scala/fi/vm/sade/hakurekisteri/integration/koski/KoskiDataHandlerTest.scala
@@ -3424,7 +3424,7 @@ class KoskiDataHandlerTest
     suoritukset.head should equal("1")
   }
 
-  it should "store alle 30 opintopisteen valma-suoritus as KESKEN before deadline date" in {
+  it should "not store alle 30 opintopisteen valma-suoritus in valmis state" in {
     val json: String =
       scala.io.Source.fromFile(jsonDir + "koskidata_valma_valmis_alle_30_op.json").mkString
     val henkilo: KoskiHenkiloContainer = parse(json).extract[KoskiHenkiloContainer]
@@ -3443,37 +3443,9 @@ class KoskiDataHandlerTest
     )
 
     var opiskelija = run(database.run(sql"select count(*) from opiskelija".as[String]))
-    opiskelija.head should equal("1")
+    opiskelija.head should equal("0")
     var suoritukset = run(database.run(sql"select count(*) from suoritus".as[String]))
-    suoritukset.head should equal("1")
-    var suoritusTilat = run(database.run(sql"select tila from suoritus".as[String]))
-    suoritusTilat.head should equal("KESKEN")
-  }
-
-  it should "store alle 30 opintopisteen valma-suoritus as KESKEYTYNYT after deadline date" in {
-    val json: String =
-      scala.io.Source.fromFile(jsonDir + "koskidata_valma_valmis_alle_30_op.json").mkString
-    val henkilo: KoskiHenkiloContainer = parse(json).extract[KoskiHenkiloContainer]
-    henkilo should not be null
-    henkilo.opiskeluoikeudet.head.tyyppi should not be empty
-
-    KoskiUtil.deadlineDate = LocalDate.now().minusDays(30)
-
-    Await.result(
-      koskiDatahandler.processHenkilonTiedotKoskesta(
-        henkilo,
-        PersonOidsWithAliases(henkilo.henkilö.oid.toSet),
-        new KoskiSuoritusHakuParams(saveLukio = true, saveAmmatillinen = true)
-      ),
-      5.seconds
-    )
-
-    var opiskelija = run(database.run(sql"select count(*) from opiskelija".as[String]))
-    opiskelija.head should equal("1")
-    var suoritukset = run(database.run(sql"select count(*) from suoritus".as[String]))
-    suoritukset.head should equal("1")
-    var suoritusTilat = run(database.run(sql"select tila from suoritus".as[String]))
-    suoritusTilat.head should equal("KESKEYTYNYT")
+    suoritukset.head should equal("0")
   }
 
   it should "set correct luokkatieto when detecting oppilaitos and luokka" in {


### PR DESCRIPTION
VALMA-suoritukset from Koski should not be stored if their total scope is <30 osp even when they are finished - because at that point that's all there will be.

This logic was apparently added some point in 2019 according to logs, but later removed either accidentally or due to a reason. Now it's required again in either case.