### PR TITLE
Valmis perusopetuksen suorituksen pitää jyrätä 9-luokan jääluokalle-tieto

### DIFF
--- a/src/main/scala/fi/vm/sade/hakurekisteri/integration/koski/KoskiDataHandler.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/integration/koski/KoskiDataHandler.scala
@@ -52,10 +52,6 @@ class KoskiDataHandler(
 
   implicit val localDateOrdering: Ordering[LocalDate] = _ compareTo _
 
-  private def loytyykoHylattyja(suoritus: KoskiSuoritus): Boolean = {
-    suoritus.osasuoritukset.exists(_.arviointi.exists(_.hyväksytty.contains(false)))
-  }
-
   private def shouldSaveSuoritus(
     henkiloOid: String,
     suoritus: KoskiSuoritus,
@@ -379,13 +375,6 @@ class KoskiDataHandler(
     }
   }
 
-  private def arvosanaForSuoritus(
-    arvosana: Arvosana,
-    s: Suoritus with Identified[UUID]
-  ): Arvosana = {
-    arvosana.copy(suoritus = s.id)
-  }
-
   private def saveArvosana(arvosana: Arvosana): Future[Any] = {
     (arvosanaRekisteri ? arvosana).recoverWith { case t: AskTimeoutException =>
       logger.error(
@@ -394,14 +383,6 @@ class KoskiDataHandler(
       )
       saveArvosana(arvosana)
     }
-  }
-
-  private def arvosanaToInsertResource(
-    arvosana: Arvosana,
-    suoritus: Suoritus with Identified[UUID],
-    personOidsWithAliases: PersonOidsWithAliases
-  ) = {
-    InsertResource[UUID, Arvosana](arvosanaForSuoritus(arvosana, suoritus), personOidsWithAliases)
   }
 
   private def getAliases(personOidsWithAliases: PersonOidsWithAliases): Set[String] = {
@@ -908,8 +889,3 @@ case class SuoritusLuokka(
   lasnaDate: LocalDate,
   luokkataso: Option[String] = None
 )
-
-case class MultipleSuoritusException(henkiloOid: String, myontaja: String, komo: String)
-    extends Exception(
-      s"Multiple suoritus found for henkilo $henkiloOid by myontaja $myontaja with komo $komo."
-    )

--- a/src/main/scala/fi/vm/sade/hakurekisteri/integration/koski/KoskiSuoritusArvosanaParser.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/integration/koski/KoskiSuoritusArvosanaParser.scala
@@ -340,11 +340,11 @@ class KoskiSuoritusArvosanaParser {
 
   private def isFailedNinthGrade(suoritus: KoskiSuoritus): Boolean = {
     val ysiluokka = suoritus.koulutusmoduuli.isNinthGrade()
-    val jaaluokalle = suoritus.jääLuokalle.getOrElse(false) == true
+    val jaaluokalle = suoritus.jääLuokalle.getOrElse(false)
     ysiluokka && jaaluokalle
   }
 
-  private def isVahvistettuPerusopetus(suoritukset: Seq[KoskiSuoritus]): Boolean = {
+  private def hasVahvistettuPerusopetus(suoritukset: Seq[KoskiSuoritus]): Boolean = {
     val vahvistettuPerusopetus = suoritukset
       .filter(_.isPerusopetuksenoppimaara())
       .filter(s =>
@@ -380,7 +380,7 @@ class KoskiSuoritusArvosanaParser {
   ): Seq[SuoritusArvosanat] = {
     var result = Seq[SuoritusArvosanat]()
     val valmisPerusopetus = isValmisPerusopetus(opiskeluoikeus)
-    val vahvistettuPerusopetuksenOppimaara = isVahvistettuPerusopetus(suoritukset)
+    val vahvistettuPerusopetuksenOppimaara = hasVahvistettuPerusopetus(suoritukset)
     val failedNinthGrade =
       hasFailedNinthGrade(suoritukset) && !(valmisPerusopetus || vahvistettuPerusopetuksenOppimaara)
     var lahdeArvot: Map[String, String] = Map[String, String]()

--- a/src/main/scala/fi/vm/sade/hakurekisteri/integration/koski/KoskiSuoritusArvosanaParser.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/integration/koski/KoskiSuoritusArvosanaParser.scala
@@ -334,7 +334,7 @@ class KoskiSuoritusArvosanaParser {
     val failed = ysiluokat.exists(_.jääLuokalle.getOrElse(false))
     // tämä taitaa olla turha koska uusittuna läpäisty 9-luokka ei oletettavasti näy 9-luokan suorituksena
     // vaan päättötodistuksena
-    val succeeded = ysiluokat.exists(_.jääLuokalle.getOrElse(false) == false)
+    val succeeded = ysiluokat.exists(!_.jääLuokalle.getOrElse(false))
     failed && !succeeded
   }
 

--- a/src/main/scala/fi/vm/sade/hakurekisteri/integration/koski/koskiDomain.scala
+++ b/src/main/scala/fi/vm/sade/hakurekisteri/integration/koski/koskiDomain.scala
@@ -204,6 +204,11 @@ case class KoskiSuoritus(
     tyyppi.exists(_.koodiarvo == "aikuistenperusopetuksenoppimaara")
   }
 
+  def isPerusopetuksenoppimaara(): Boolean = {
+    tyyppi.exists(_.koodiarvo == "perusopetuksenoppimaara") ||
+    tyyppi.exists(_.koodiarvo == "aikuistenperusopetuksenoppimaara")
+  }
+
   def laajuusVahintaan(min: BigDecimal): Boolean = {
     val sum =
       if (isOpistovuosi) {

--- a/src/test/scala/fi/vm/sade/hakurekisteri/integration/koski/KoskiDataHandlerTest.scala
+++ b/src/test/scala/fi/vm/sade/hakurekisteri/integration/koski/KoskiDataHandlerTest.scala
@@ -380,7 +380,7 @@ class KoskiDataHandlerTest
     lasnaOpiskeluOikeudet should have length 1
   }
 
-  it should "parse peruskoulu_9_luokka_päättötodistus_jää_luokalle.json data as keskeytynyt after deadline" in {
+  it should "parse peruskoulu_9_luokka_päättötodistus_jää_luokalle.json data as valmis after deadline" in {
     val json: String = scala.io.Source
       .fromFile(jsonDir + "peruskoulu_9_luokka_päättötodistus_jää_luokalle.json")
       .mkString
@@ -401,13 +401,13 @@ class KoskiDataHandlerTest
 
     val virallinenpaattotodistus = paattotodistus.suoritus
     virallinenpaattotodistus.komo shouldNot be("luokka")
-    paattotodistus.arvosanat should have length 0
-    virallinenpaattotodistus.tila should equal("KESKEYTYNYT")
+    paattotodistus.arvosanat should have length 18
+    virallinenpaattotodistus.tila should equal("VALMIS")
 
     peruskouluB2KieletShouldNotBeValinnainen(result)
   }
 
-  it should "parse peruskoulu_9_luokka_päättötodistus_jää_luokalle.json data as keskeytynyt if set jää luokalle in koski before deadline" in {
+  it should "parse peruskoulu_9_luokka_päättötodistus_jää_luokalle.json data as valmis if set jää luokalle in koski before deadline" in {
     val json: String = scala.io.Source
       .fromFile(jsonDir + "peruskoulu_9_luokka_päättötodistus_jää_luokalle.json")
       .mkString
@@ -428,8 +428,8 @@ class KoskiDataHandlerTest
 
     val virallinenpaattotodistus = paattotodistus.suoritus
     virallinenpaattotodistus.komo shouldNot be("luokka")
-    paattotodistus.arvosanat should have length 0
-    virallinenpaattotodistus.tila should equal("KESKEYTYNYT")
+    paattotodistus.arvosanat should have length 18
+    virallinenpaattotodistus.tila should equal("VALMIS")
 
     peruskouluB2KieletShouldNotBeValinnainen(result)
   }
@@ -464,6 +464,82 @@ class KoskiDataHandlerTest
     val pt = getPerusopetusPäättötodistus(result).get
     pt.suoritus.tila shouldEqual "VALMIS"
     pt.arvosanat should have length 18
+  }
+
+  it should "store valmis perusopetuksen erityinen tutkinto as valmis even if jääluokalle is true in 9luokka" in {
+    val json: String = scala.io.Source
+      .fromFile(jsonDir + "koskidata_perusopetus_valmis_erityinen_jaanyt_9luokalle.json")
+      .mkString
+    val henkilo: KoskiHenkiloContainer = parse(json).extract[KoskiHenkiloContainer]
+    henkilo should not be null
+    henkilo.opiskeluoikeudet.head.tyyppi should not be empty
+    KoskiUtil.deadlineDate = LocalDate.now().plusDays(1)
+
+    val arvosanat1 = run(database.run(sql"select count(*) from arvosana".as[String]))
+    arvosanat1.head should equal("0")
+
+    Await.result(
+      koskiDatahandler.processHenkilonTiedotKoskesta(
+        henkilo,
+        PersonOidsWithAliases(henkilo.henkilö.oid.toSet),
+        new KoskiSuoritusHakuParams(saveLukio = true, saveAmmatillinen = true)
+      ),
+      5.seconds
+    )
+    //komo
+    val suorituskomot = run(database.run(sql"select komo from suoritus".as[String]))
+    suorituskomot.size should equal(1)
+    suorituskomot.head should equal("1.2.246.562.13.62959769647")
+    val suoritustilat = run(database.run(sql"select tila from suoritus".as[String]))
+    suoritustilat.size should equal(1)
+    suoritustilat.head should equal("VALMIS")
+    val arvosanat = run(database.run(sql"select count(*) from arvosana".as[String]))
+    arvosanat.head should equal("17")
+  }
+
+  it should "parse valmis perusopetus as valmis even if jääluokalle is true in 9luokka" in {
+    val json: String = scala.io.Source
+      .fromFile(jsonDir + "koskidata_perusopetus_valmis_jaanyt_9luokalle.json")
+      .mkString
+    val henkilo: KoskiHenkiloContainer = parse(json).extract[KoskiHenkiloContainer]
+    henkilo should not be null
+    henkilo.opiskeluoikeudet.head.tyyppi should not be empty
+    KoskiUtil.deadlineDate = LocalDate.now().plusDays(1)
+
+    val result = koskiDatahandler.createSuorituksetJaArvosanatFromKoski(henkilo).head
+    result should have length 2
+    val pt = getPerusopetusPäättötodistus(result)
+    pt.get.suoritus.tila shouldBe "VALMIS"
+  }
+
+  it should "parse keskeneräinen perusopetus as kesken and no arvosanat when jääluokalle is true in 9luokka before deadline" in {
+    val json: String = scala.io.Source
+      .fromFile(jsonDir + "koskidata_perusopetus_kesken_jaanyt_9luokalle.json")
+      .mkString
+    val henkilo: KoskiHenkiloContainer = parse(json).extract[KoskiHenkiloContainer]
+    henkilo should not be null
+    henkilo.opiskeluoikeudet.head.tyyppi should not be empty
+    KoskiUtil.deadlineDate = LocalDate.now().plusDays(1)
+
+    val result = koskiDatahandler.createSuorituksetJaArvosanatFromKoski(henkilo).head
+    //result should have length 0
+    val pt = getPerusopetusPäättötodistus(result)
+    pt.get.suoritus.tila shouldBe "KESKEYTYNYT"
+  }
+
+  it should "parse keskeneräinen perusopetus as kesken and no arvosanat when jääluokalle is true in 9luokka after deadline" in {
+    val json: String = scala.io.Source
+      .fromFile(jsonDir + "koskidata_perusopetus_kesken_jaanyt_9luokalle.json")
+      .mkString
+    val henkilo: KoskiHenkiloContainer = parse(json).extract[KoskiHenkiloContainer]
+    henkilo should not be null
+    henkilo.opiskeluoikeudet.head.tyyppi should not be empty
+    KoskiUtil.deadlineDate = LocalDate.now().minusDays(1)
+
+    val result = koskiDatahandler.createSuorituksetJaArvosanatFromKoski(henkilo).head
+    //result should have length 0
+    val pt = getPerusopetusPäättötodistus(result)
+    pt.get.suoritus.tila shouldBe "KESKEYTYNYT"
   }
 
   it should "parse peruskoulu_9_luokka_päättötodistus_vuosiluokkiinSitoutumatonOpetus_true.json data" in {
@@ -1053,7 +1129,8 @@ class KoskiDataHandlerTest
     ysiluokat should have length 1
     ysiluokat.head.suoritus.valmistuminen.toString("dd.MM.YYYY") shouldEqual KoskiUtil.deadlineDate
       .toString("dd.MM.YYYY")
-    pt.suoritus.valmistuminen.toString("dd.MM.YYYY") shouldEqual "01.06.2017"
+    // 4.6.2016 vahvistettu perusopetuksen oppimäärä jyrää luokallejäädyn ysiluokan vahvistuksen 1.6.2017
+    pt.suoritus.valmistuminen.toString("dd.MM.YYYY") shouldEqual "04.06.2016"
 
   }
 
@@ -1215,8 +1292,8 @@ class KoskiDataHandlerTest
     val result: Seq[SuoritusArvosanat] = resultgroup.head
     result should have length 2
     val arvosanat = result.head
-
-    val expectedDate = LocalDate.parse("2018-05-15")
+    // perusopetuksen vahvistus 6.4.2016, opiskeluoikeuden aikaleima 15.5.2018
+    val expectedDate = LocalDate.parse("2016-06-04")
     arvosanat.suoritus.valmistuminen shouldEqual expectedDate
   }
 
@@ -1290,74 +1367,6 @@ class KoskiDataHandlerTest
     valinnaisetAineet shouldNot contain("KU")
     valinnaisetAineet should contain("AI")
   }
-
-  /*it should "parse vahvistamaton telma_testi_valmis.json as keskeytynyt after deadline date" in {
-    val json: String = scala.io.Source.fromFile(jsonDir + "telma_testi_valmis.json").mkString
-    val henkilo: KoskiHenkiloContainer = parse(json).extract[KoskiHenkiloContainer]
-
-    henkilo should not be null
-    henkilo.opiskeluoikeudet.head.tyyppi should not be empty
-
-    KoskiUtil.deadlineDate = LocalDate.now().minusDays(1)
-
-    val resultgrp = koskiDatahandler.createSuorituksetJaArvosanatFromKoski(henkilo)
-    resultgrp should have length 1
-    val result = resultgrp.head
-    result should have length 1
-    result.head.arvosanat should have length 0
-    result.head.suoritus.tila shouldEqual "KESKEYTYNYT"
-  }*/
-
-  /*it should "parse vahvistamaton telma_testi_valmis.json as kesken before deadline date" in {
-    val json: String = scala.io.Source.fromFile(jsonDir + "telma_testi_valmis.json").mkString
-    val henkilo: KoskiHenkiloContainer = parse(json).extract[KoskiHenkiloContainer]
-
-    henkilo should not be null
-    henkilo.opiskeluoikeudet.head.tyyppi should not be empty
-
-    KoskiUtil.deadlineDate = LocalDate.now().plusDays(1)
-
-    val resultgrp = koskiDatahandler.createSuorituksetJaArvosanatFromKoski(henkilo)
-    resultgrp should have length 1
-    val result = resultgrp.head
-    result should have length 1
-    result.head.arvosanat should have length 0
-    result.head.suoritus.tila shouldEqual "KESKEN"
-  }*/
-
-  /*it should "parse telma_testi_kesken.json as keskeytynyt after deadline date" in {
-    val json: String = scala.io.Source.fromFile(jsonDir + "telma_testi_kesken.json").mkString
-    val henkilo: KoskiHenkiloContainer = parse(json).extract[KoskiHenkiloContainer]
-
-    henkilo should not be null
-    henkilo.opiskeluoikeudet.head.tyyppi should not be empty
-
-    KoskiUtil.deadlineDate = LocalDate.now().minusDays(1)
-
-    val resultgrp = koskiDatahandler.createSuorituksetJaArvosanatFromKoski(henkilo)
-    resultgrp should have length 1
-    val result = resultgrp.head
-    result should have length 1
-    result.head.arvosanat should have length 0
-    result.head.suoritus.tila shouldEqual "KESKEYTYNYT"
-  }*/
-
-  /*it should "parse telma_testi_kesken.json as kesken before deadline date" in {
-    val json: String = scala.io.Source.fromFile(jsonDir + "telma_testi_kesken.json").mkString
-    val henkilo: KoskiHenkiloContainer = parse(json).extract[KoskiHenkiloContainer]
-
-    henkilo should not be null
-    henkilo.opiskeluoikeudet.head.tyyppi should not be empty
-
-    KoskiUtil.deadlineDate = LocalDate.now().plusDays(1)
-
-    val resultgrp = koskiDatahandler.createSuorituksetJaArvosanatFromKoski(henkilo)
-    resultgrp should have length 1
-    val result = resultgrp.head
-    result should have length 1
-    result.head.arvosanat should have length 0
-    result.head.suoritus.tila shouldEqual "KESKEN"
-  }*/
 
   it should "parse kielivalinnaisuustest.json" in {
     val json: String = scala.io.Source.fromFile(jsonDir + "kielivalinnaisuustest.json").mkString
@@ -2835,44 +2844,6 @@ class KoskiDataHandlerTest
     )
     arvosanat should have length 0
   }
-
-  /*it should "store telma as kesken without arvosanat if deadline date is tomorrow and not enough opintopistees" in {
-    val json: String = scala.io.Source.fromFile(jsonDir + "telma_testi_kesken.json").mkString
-    val henkilo: KoskiHenkiloContainer = parse(json).extract[KoskiHenkiloContainer]
-    henkilo should not be null
-    henkilo.opiskeluoikeudet.head.tyyppi should not be empty
-    KoskiUtil.deadlineDate = LocalDate.now().plusDays(1)
-
-    Await.result(koskiDatahandler.processHenkilonTiedotKoskesta(henkilo,PersonOidsWithAliases(henkilo.henkilö.oid.toSet), new KoskiSuoritusHakuParams(saveLukio = false, saveAmmatillinen = false)), 5.seconds)
-
-    val opiskelijat = run(database.run(sql"select henkilo_oid from opiskelija".as[String]))
-    opiskelijat.size should equal(1)
-    val suoritukset = run(database.run(sql"select count(*) from suoritus".as[String]))
-    suoritukset.head should equal ("1")
-    val suoritus = run(database.run(sql"select tila from suoritus where komo = 'telma'".as[String]))
-    suoritus.head should equal("KESKEN")
-    val arvosanat = run(database.run(sql"select * from arvosana where deleted = false and current = true".as[String]))
-    arvosanat should have length 0
-  }*/
-
-  /*it should "store telma as keskeytynyt without arvosanat if deadline date is yesterday" in {
-    val json: String = scala.io.Source.fromFile(jsonDir + "telma_testi_kesken.json").mkString
-    val henkilo: KoskiHenkiloContainer = parse(json).extract[KoskiHenkiloContainer]
-    henkilo should not be null
-    henkilo.opiskeluoikeudet.head.tyyppi should not be empty
-    KoskiUtil.deadlineDate = LocalDate.now().minusDays(1)
-
-    Await.result(koskiDatahandler.processHenkilonTiedotKoskesta(henkilo,PersonOidsWithAliases(henkilo.henkilö.oid.toSet), new KoskiSuoritusHakuParams(saveLukio = false, saveAmmatillinen = false)), 5.seconds)
-
-    val opiskelijat = run(database.run(sql"select henkilo_oid from opiskelija".as[String]))
-    opiskelijat.size should equal(1)
-    val suoritukset = run(database.run(sql"select count(*) from suoritus".as[String]))
-    suoritukset.head should equal ("1")
-    val suoritus = run(database.run(sql"select tila from suoritus where komo = 'telma'".as[String]))
-    suoritus.head should equal("KESKEYTYNYT")
-    val arvosanat = run(database.run(sql"select * from arvosana where deleted = false and current = true".as[String]))
-    arvosanat should have length 0
-  }*/
 
   it should "store vuosiluokkiin sitomaton as kesken without arvosanat if deadline date is tomorrow" in {
     val json: String = scala.io.Source.fromFile(jsonDir + "koskidata_sitomaton.json").mkString

--- a/src/test/scala/fi/vm/sade/hakurekisteri/integration/koski/KoskiDataHandlerTest.scala
+++ b/src/test/scala/fi/vm/sade/hakurekisteri/integration/koski/KoskiDataHandlerTest.scala
@@ -1020,7 +1020,6 @@ class KoskiDataHandlerTest
     Valmistumispäivämäärä ei päivittynyt todistuksen vahvistuspäivämääräkentästä kosken puolelta sureen,
     ennen kuin opiskeluoideuden tilan oli muuttanut valmiiksi koskessa. Olisi pitänyt päivittyä jo silloin,
     kun päättötodistus vahvistettiin. (Vaikka opiskeluoikeuden tila oli kesken)
-    Testattu tapauksella 080501A660R
      */
 
     val json: String = scala.io.Source.fromFile(jsonDir + "luokallejaanyt_conflu_10.json").mkString

--- a/src/test/scala/fi/vm/sade/hakurekisteri/integration/koski/KoskiDataHandlerTest.scala
+++ b/src/test/scala/fi/vm/sade/hakurekisteri/integration/koski/KoskiDataHandlerTest.scala
@@ -512,7 +512,7 @@ class KoskiDataHandlerTest
     pt.get.suoritus.tila shouldBe "VALMIS"
   }
 
-  it should "parse keskeneräinen perusopetus as kesken and no arvosanat when jääluokalle is true in 9luokka before deadline" in {
+  it should "parse keskeneräinen perusopetus as keskeytynyt and no arvosanat when jääluokalle is true in 9luokka before deadline" in {
     val json: String = scala.io.Source
       .fromFile(jsonDir + "koskidata_perusopetus_kesken_jaanyt_9luokalle.json")
       .mkString
@@ -522,12 +522,15 @@ class KoskiDataHandlerTest
     KoskiUtil.deadlineDate = LocalDate.now().plusDays(1)
 
     val result = koskiDatahandler.createSuorituksetJaArvosanatFromKoski(henkilo).head
-    //result should have length 0
+    result should have length 2
+    // ei 9-luokan eikä päättötodistuksen arvosanoja
+    result(0).arvosanat should have length 0
+    result(1).arvosanat should have length 0
     val pt = getPerusopetusPäättötodistus(result)
     pt.get.suoritus.tila shouldBe "KESKEYTYNYT"
   }
 
-  it should "parse keskeneräinen perusopetus as kesken and no arvosanat when jääluokalle is true in 9luokka after deadline" in {
+  it should "parse keskeneräinen perusopetus as keskeytynyt and no arvosanat when jääluokalle is true in 9luokka after deadline" in {
     val json: String = scala.io.Source
       .fromFile(jsonDir + "koskidata_perusopetus_kesken_jaanyt_9luokalle.json")
       .mkString
@@ -537,7 +540,10 @@ class KoskiDataHandlerTest
     KoskiUtil.deadlineDate = LocalDate.now().minusDays(1)
 
     val result = koskiDatahandler.createSuorituksetJaArvosanatFromKoski(henkilo).head
-    //result should have length 0
+    result should have length 2
+    // ei 9-luokan eikä päättötodistuksen arvosanoja
+    result(0).arvosanat should have length 0
+    result(1).arvosanat should have length 0
     val pt = getPerusopetusPäättötodistus(result)
     pt.get.suoritus.tila shouldBe "KESKEYTYNYT"
   }

--- a/src/test/scala/fi/vm/sade/hakurekisteri/integration/koski/json/koskidata_perusopetus_kesken_jaanyt_9luokalle.json
+++ b/src/test/scala/fi/vm/sade/hakurekisteri/integration/koski/json/koskidata_perusopetus_kesken_jaanyt_9luokalle.json
@@ -1,0 +1,2244 @@
+{
+  "henkilö": {
+    "oid": "1.2.246.562.24.48863850077",
+    "hetu": "010110A9290",
+    "syntymäaika": "2010-01-01",
+    "etunimet": "Jarkko Testi",
+    "kutsumanimi": "Jarkko",
+    "sukunimi": "Kurvinen-Testi",
+    "äidinkieli": {
+      "koodiarvo": "FI",
+      "nimi": {
+        "fi": "suomi",
+        "sv": "finska",
+        "en": "Finnish"
+      },
+      "lyhytNimi": {
+        "fi": "suomi",
+        "sv": "finska",
+        "en": "Finnish"
+      },
+      "koodistoUri": "kieli",
+      "koodistoVersio": 1
+    },
+    "kansalaisuus": [
+      {
+        "koodiarvo": "246",
+        "nimi": {
+          "fi": "Suomi",
+          "sv": "Finland",
+          "en": "Finland"
+        },
+        "lyhytNimi": {
+          "fi": "FI",
+          "sv": "FI",
+          "en": "FI"
+        },
+        "koodistoUri": "maatjavaltiot2",
+        "koodistoVersio": 2
+      }
+    ],
+    "turvakielto": false
+  },
+  "opiskeluoikeudet": [
+    {
+      "oid": "1.2.246.562.15.52966253248",
+      "versionumero": 4,
+      "aikaleima": "2024-05-08T10:29:31.876422",
+      "oppilaitos": {
+        "oid": "1.2.246.562.10.81837391655",
+        "oppilaitosnumero": {
+          "koodiarvo": "06330",
+          "nimi": {
+            "fi": "Kaukovainion koulu",
+            "sv": "Kaukovainion koulu",
+            "en": "Kaukovainion koulu"
+          },
+          "lyhytNimi": {
+            "fi": "Kaukovainion koulu",
+            "sv": "Kaukovainion koulu",
+            "en": "Kaukovainion koulu"
+          },
+          "koodistoUri": "oppilaitosnumero",
+          "koodistoVersio": 1
+        },
+        "nimi": {
+          "fi": "Kaukovainion koulu",
+          "sv": "Kaukovainion koulu",
+          "en": "Kaukovainion koulu"
+        },
+        "kotipaikka": {
+          "koodiarvo": "564",
+          "nimi": {
+            "fi": "Oulu",
+            "sv": "Uleåborg"
+          },
+          "koodistoUri": "kunta",
+          "koodistoVersio": 2
+        }
+      },
+      "koulutustoimija": {
+        "oid": "1.2.246.562.10.80381044462",
+        "nimi": {
+          "fi": "Oulun kaupunki",
+          "sv": "Oulun kaupunki",
+          "en": "Oulun kaupunki"
+        },
+        "yTunnus": "0187690-1",
+        "kotipaikka": {
+          "koodiarvo": "564",
+          "nimi": {
+            "fi": "Oulu",
+            "sv": "Uleåborg"
+          },
+          "koodistoUri": "kunta",
+          "koodistoVersio": 2
+        }
+      },
+      "tila": {
+        "opiskeluoikeusjaksot": [
+          {
+            "alku": "2023-08-09",
+            "tila": {
+              "koodiarvo": "lasna",
+              "nimi": {
+                "fi": "Läsnä",
+                "sv": "Närvarande",
+                "en": "Present"
+              },
+              "koodistoUri": "koskiopiskeluoikeudentila",
+              "koodistoVersio": 1
+            }
+          }
+        ]
+      },
+      "suoritukset": [
+        {
+          "koulutusmoduuli": {
+            "perusteenDiaarinumero": "104/011/2014",
+            "tunniste": {
+              "koodiarvo": "201101",
+              "nimi": {
+                "fi": "Perusopetus",
+                "sv": "Grundläggande utbildning",
+                "en": "Basic education"
+              },
+              "koodistoUri": "koulutus",
+              "koodistoVersio": 12
+            },
+            "koulutustyyppi": {
+              "koodiarvo": "16",
+              "nimi": {
+                "fi": "Perusopetus",
+                "sv": "Grundläggande utbildning"
+              },
+              "lyhytNimi": {
+                "fi": "Perusopetus",
+                "sv": "Grundläggande utbildning"
+              },
+              "koodistoUri": "koulutustyyppi"
+            }
+          },
+          "toimipiste": {
+            "oid": "1.2.246.562.10.81837391655",
+            "oppilaitosnumero": {
+              "koodiarvo": "06330",
+              "nimi": {
+                "fi": "Kaukovainion koulu",
+                "sv": "Kaukovainion koulu",
+                "en": "Kaukovainion koulu"
+              },
+              "lyhytNimi": {
+                "fi": "Kaukovainion koulu",
+                "sv": "Kaukovainion koulu",
+                "en": "Kaukovainion koulu"
+              },
+              "koodistoUri": "oppilaitosnumero",
+              "koodistoVersio": 1
+            },
+            "nimi": {
+              "fi": "Kaukovainion koulu",
+              "sv": "Kaukovainion koulu",
+              "en": "Kaukovainion koulu"
+            },
+            "kotipaikka": {
+              "koodiarvo": "564",
+              "nimi": {
+                "fi": "Oulu",
+                "sv": "Uleåborg"
+              },
+              "koodistoUri": "kunta",
+              "koodistoVersio": 2
+            }
+          },
+          "suoritustapa": {
+            "koodiarvo": "koulutus",
+            "nimi": {
+              "fi": "Koulutus",
+              "sv": "Utbildning",
+              "en": "Education"
+            },
+            "koodistoUri": "perusopetuksensuoritustapa",
+            "koodistoVersio": 1
+          },
+          "suorituskieli": {
+            "koodiarvo": "FI",
+            "nimi": {
+              "fi": "suomi",
+              "sv": "finska",
+              "en": "Finnish"
+            },
+            "lyhytNimi": {
+              "fi": "suomi",
+              "sv": "finska",
+              "en": "Finnish"
+            },
+            "koodistoUri": "kieli",
+            "koodistoVersio": 1
+          },
+          "osasuoritukset": [
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "AI",
+                  "nimi": {
+                    "fi": "Äidinkieli ja kirjallisuus",
+                    "sv": "Modersmålet och litteratur",
+                    "en": "Mother tongue and literature"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Äidinkieli ja kirjallisuus",
+                    "sv": "Modersmålet och litteratur"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "kieli": {
+                  "koodiarvo": "AI1",
+                  "nimi": {
+                    "fi": "Suomen kieli ja kirjallisuus",
+                    "sv": "Finska och litteratur",
+                    "en": "Finnish language and literature"
+                  },
+                  "koodistoUri": "oppiaineaidinkielijakirjallisuus",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "A1",
+                  "nimi": {
+                    "fi": "A1-kieli",
+                    "sv": "A1-språk",
+                    "en": "A1-language"
+                  },
+                  "lyhytNimi": {
+                    "fi": "A1-kieli",
+                    "sv": "A1-språk"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "kieli": {
+                  "koodiarvo": "EN",
+                  "nimi": {
+                    "fi": "englanti",
+                    "sv": "engelska",
+                    "en": "English"
+                  },
+                  "lyhytNimi": {
+                    "fi": "englanti",
+                    "sv": "engelska",
+                    "en": "English"
+                  },
+                  "koodistoUri": "kielivalikoima",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "B1",
+                  "nimi": {
+                    "fi": "B1-kieli",
+                    "sv": "B1-språk",
+                    "en": "B1-language"
+                  },
+                  "lyhytNimi": {
+                    "fi": "B1-kieli",
+                    "sv": "B1-språk"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "kieli": {
+                  "koodiarvo": "SV",
+                  "nimi": {
+                    "fi": "ruotsi",
+                    "sv": "svenska",
+                    "en": "Swedish"
+                  },
+                  "lyhytNimi": {
+                    "fi": "ruotsi",
+                    "sv": "svenska",
+                    "en": "Swedish"
+                  },
+                  "koodistoUri": "kielivalikoima",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "MA",
+                  "nimi": {
+                    "fi": "Matematiikka",
+                    "sv": "Matematik",
+                    "en": "Mathematics"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Matematiikka",
+                    "sv": "Matematik"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "BI",
+                  "nimi": {
+                    "fi": "Biologia",
+                    "sv": "Biologi",
+                    "en": "Biology"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Biologia",
+                    "sv": "Biologi"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "GE",
+                  "nimi": {
+                    "fi": "Maantieto",
+                    "sv": "Geografi",
+                    "en": "Geography"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Maantieto",
+                    "sv": "Geografi"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "FY",
+                  "nimi": {
+                    "fi": "Fysiikka",
+                    "sv": "Fysik",
+                    "en": "Physics"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Fysiikka",
+                    "sv": "Fysik"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "KE",
+                  "nimi": {
+                    "fi": "Kemia",
+                    "sv": "Kemi",
+                    "en": "Chemistry"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Kemia",
+                    "sv": "Kemi"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "TE",
+                  "nimi": {
+                    "fi": "Terveystieto",
+                    "sv": "Hälsokunskap",
+                    "en": "Health education"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Terveystieto",
+                    "sv": "Hälsokunskap"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "KT",
+                  "nimi": {
+                    "fi": "Uskonto/Elämänkatsomustieto",
+                    "sv": "Religion/Livsåskådningskunskap",
+                    "en": "Religion/ethics"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Uskonto",
+                    "sv": "Religion"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "HI",
+                  "nimi": {
+                    "fi": "Historia",
+                    "sv": "Historia",
+                    "en": "History"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Historia",
+                    "sv": "Historia"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "YH",
+                  "nimi": {
+                    "fi": "Yhteiskuntaoppi",
+                    "sv": "Samhällslära",
+                    "en": "Social studies"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Yhteiskuntaoppi",
+                    "sv": "Samhällslära"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "MU",
+                  "nimi": {
+                    "fi": "Musiikki",
+                    "sv": "Musik",
+                    "en": "Music"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Musiikki",
+                    "sv": "Musik"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "KU",
+                  "nimi": {
+                    "fi": "Kuvataide",
+                    "sv": "Bildkonst",
+                    "en": "Visual arts"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Kuvataide",
+                    "sv": "Bildkonst"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "KS",
+                  "nimi": {
+                    "fi": "Käsityö",
+                    "sv": "Slöjd",
+                    "en": "Crafts"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Käsityö",
+                    "sv": "Slöjd"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LI",
+                  "nimi": {
+                    "fi": "Liikunta",
+                    "sv": "Gymnastik",
+                    "en": "Physical education"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Liikunta",
+                    "sv": "Gymnastik"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "KO",
+                  "nimi": {
+                    "fi": "Kotitalous",
+                    "sv": "Huslig ekonomi",
+                    "en": "Home economics"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Kotitalous",
+                    "sv": "Huslig ekonomi"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "OP",
+                  "nimi": {
+                    "fi": "Opinto-ohjaus",
+                    "sv": "Elevhandledning",
+                    "en": "Guidance counselling"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Opinto-ohjaus"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            }
+          ],
+          "tyyppi": {
+            "koodiarvo": "perusopetuksenoppimaara",
+            "nimi": {
+              "fi": "Perusopetuksen oppimäärä",
+              "sv": "Grundläggande utbildningens lärokurs",
+              "en": "Basic education syllabus"
+            },
+            "koodistoUri": "suorituksentyyppi",
+            "koodistoVersio": 1
+          }
+        },
+        {
+          "koulutusmoduuli": {
+            "tunniste": {
+              "koodiarvo": "9",
+              "nimi": {
+                "fi": "9. vuosiluokka",
+                "sv": "Årskurs 9",
+                "en": "9th grade"
+              },
+              "koodistoUri": "perusopetuksenluokkaaste",
+              "koodistoVersio": 1
+            },
+            "perusteenDiaarinumero": "104/011/2014",
+            "koulutustyyppi": {
+              "koodiarvo": "16",
+              "nimi": {
+                "fi": "Perusopetus",
+                "sv": "Grundläggande utbildning"
+              },
+              "lyhytNimi": {
+                "fi": "Perusopetus",
+                "sv": "Grundläggande utbildning"
+              },
+              "koodistoUri": "koulutustyyppi"
+            }
+          },
+          "luokka": "9A",
+          "toimipiste": {
+            "oid": "1.2.246.562.10.81837391655",
+            "oppilaitosnumero": {
+              "koodiarvo": "06330",
+              "nimi": {
+                "fi": "Kaukovainion koulu",
+                "sv": "Kaukovainion koulu",
+                "en": "Kaukovainion koulu"
+              },
+              "lyhytNimi": {
+                "fi": "Kaukovainion koulu",
+                "sv": "Kaukovainion koulu",
+                "en": "Kaukovainion koulu"
+              },
+              "koodistoUri": "oppilaitosnumero",
+              "koodistoVersio": 1
+            },
+            "nimi": {
+              "fi": "Kaukovainion koulu",
+              "sv": "Kaukovainion koulu",
+              "en": "Kaukovainion koulu"
+            },
+            "kotipaikka": {
+              "koodiarvo": "564",
+              "nimi": {
+                "fi": "Oulu",
+                "sv": "Uleåborg"
+              },
+              "koodistoUri": "kunta",
+              "koodistoVersio": 2
+            }
+          },
+          "alkamispäivä": "2023-08-09",
+          "vahvistus": {
+            "päivä": "2024-05-08",
+            "paikkakunta": {
+              "koodiarvo": "564",
+              "nimi": {
+                "fi": "Oulu",
+                "sv": "Uleåborg"
+              },
+              "koodistoUri": "kunta",
+              "koodistoVersio": 2
+            },
+            "myöntäjäOrganisaatio": {
+              "oid": "1.2.246.562.10.81837391655",
+              "oppilaitosnumero": {
+                "koodiarvo": "06330",
+                "nimi": {
+                  "fi": "Kaukovainion koulu",
+                  "sv": "Kaukovainion koulu",
+                  "en": "Kaukovainion koulu"
+                },
+                "lyhytNimi": {
+                  "fi": "Kaukovainion koulu",
+                  "sv": "Kaukovainion koulu",
+                  "en": "Kaukovainion koulu"
+                },
+                "koodistoUri": "oppilaitosnumero",
+                "koodistoVersio": 1
+              },
+              "nimi": {
+                "fi": "Kaukovainion koulu",
+                "sv": "Kaukovainion koulu",
+                "en": "Kaukovainion koulu"
+              },
+              "kotipaikka": {
+                "koodiarvo": "564",
+                "nimi": {
+                  "fi": "Oulu",
+                  "sv": "Uleåborg"
+                },
+                "koodistoUri": "kunta",
+                "koodistoVersio": 2
+              }
+            },
+            "myöntäjäHenkilöt": [
+              {
+                "nimi": "essi esimerkki",
+                "titteli": {
+                  "fi": "rehtori"
+                },
+                "organisaatio": {
+                  "oid": "1.2.246.562.10.81837391655",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "06330",
+                    "nimi": {
+                      "fi": "Kaukovainion koulu",
+                      "sv": "Kaukovainion koulu",
+                      "en": "Kaukovainion koulu"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Kaukovainion koulu",
+                      "sv": "Kaukovainion koulu",
+                      "en": "Kaukovainion koulu"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Kaukovainion koulu",
+                    "sv": "Kaukovainion koulu",
+                    "en": "Kaukovainion koulu"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "564",
+                    "nimi": {
+                      "fi": "Oulu",
+                      "sv": "Uleåborg"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              }
+            ]
+          },
+          "suorituskieli": {
+            "koodiarvo": "FI",
+            "nimi": {
+              "fi": "suomi",
+              "sv": "finska",
+              "en": "Finnish"
+            },
+            "lyhytNimi": {
+              "fi": "suomi",
+              "sv": "finska",
+              "en": "Finnish"
+            },
+            "koodistoUri": "kieli",
+            "koodistoVersio": 1
+          },
+          "jääLuokalle": true,
+          "osasuoritukset": [
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "AI",
+                  "nimi": {
+                    "fi": "Äidinkieli ja kirjallisuus",
+                    "sv": "Modersmålet och litteratur",
+                    "en": "Mother tongue and literature"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Äidinkieli ja kirjallisuus",
+                    "sv": "Modersmålet och litteratur"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "kieli": {
+                  "koodiarvo": "AI1",
+                  "nimi": {
+                    "fi": "Suomen kieli ja kirjallisuus",
+                    "sv": "Finska och litteratur",
+                    "en": "Finnish language and literature"
+                  },
+                  "koodistoUri": "oppiaineaidinkielijakirjallisuus",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 2,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "5",
+                    "nimi": {
+                      "fi": "välttävä",
+                      "sv": "försvarlig",
+                      "en": "adequate"
+                    },
+                    "lyhytNimi": {
+                      "fi": "5"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "A1",
+                  "nimi": {
+                    "fi": "A1-kieli",
+                    "sv": "A1-språk",
+                    "en": "A1-language"
+                  },
+                  "lyhytNimi": {
+                    "fi": "A1-kieli",
+                    "sv": "A1-språk"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "kieli": {
+                  "koodiarvo": "EN",
+                  "nimi": {
+                    "fi": "englanti",
+                    "sv": "engelska",
+                    "en": "English"
+                  },
+                  "lyhytNimi": {
+                    "fi": "englanti",
+                    "sv": "engelska",
+                    "en": "English"
+                  },
+                  "koodistoUri": "kielivalikoima",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 2,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "5",
+                    "nimi": {
+                      "fi": "välttävä",
+                      "sv": "försvarlig",
+                      "en": "adequate"
+                    },
+                    "lyhytNimi": {
+                      "fi": "5"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "B1",
+                  "nimi": {
+                    "fi": "B1-kieli",
+                    "sv": "B1-språk",
+                    "en": "B1-language"
+                  },
+                  "lyhytNimi": {
+                    "fi": "B1-kieli",
+                    "sv": "B1-språk"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "kieli": {
+                  "koodiarvo": "SV",
+                  "nimi": {
+                    "fi": "ruotsi",
+                    "sv": "svenska",
+                    "en": "Swedish"
+                  },
+                  "lyhytNimi": {
+                    "fi": "ruotsi",
+                    "sv": "svenska",
+                    "en": "Swedish"
+                  },
+                  "koodistoUri": "kielivalikoima",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 2,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "4",
+                    "nimi": {
+                      "fi": "hylätty",
+                      "sv": "underkänd",
+                      "en": "fail"
+                    },
+                    "lyhytNimi": {
+                      "fi": "4"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": false
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "MA",
+                  "nimi": {
+                    "fi": "Matematiikka",
+                    "sv": "Matematik",
+                    "en": "Mathematics"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Matematiikka",
+                    "sv": "Matematik"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 2,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "4",
+                    "nimi": {
+                      "fi": "hylätty",
+                      "sv": "underkänd",
+                      "en": "fail"
+                    },
+                    "lyhytNimi": {
+                      "fi": "4"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": false
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "BI",
+                  "nimi": {
+                    "fi": "Biologia",
+                    "sv": "Biologi",
+                    "en": "Biology"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Biologia",
+                    "sv": "Biologi"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 2,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "5",
+                    "nimi": {
+                      "fi": "välttävä",
+                      "sv": "försvarlig",
+                      "en": "adequate"
+                    },
+                    "lyhytNimi": {
+                      "fi": "5"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "GE",
+                  "nimi": {
+                    "fi": "Maantieto",
+                    "sv": "Geografi",
+                    "en": "Geography"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Maantieto",
+                    "sv": "Geografi"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 2,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "5",
+                    "nimi": {
+                      "fi": "välttävä",
+                      "sv": "försvarlig",
+                      "en": "adequate"
+                    },
+                    "lyhytNimi": {
+                      "fi": "5"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "FY",
+                  "nimi": {
+                    "fi": "Fysiikka",
+                    "sv": "Fysik",
+                    "en": "Physics"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Fysiikka",
+                    "sv": "Fysik"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 2,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "5",
+                    "nimi": {
+                      "fi": "välttävä",
+                      "sv": "försvarlig",
+                      "en": "adequate"
+                    },
+                    "lyhytNimi": {
+                      "fi": "5"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "KE",
+                  "nimi": {
+                    "fi": "Kemia",
+                    "sv": "Kemi",
+                    "en": "Chemistry"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Kemia",
+                    "sv": "Kemi"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 2,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "5",
+                    "nimi": {
+                      "fi": "välttävä",
+                      "sv": "försvarlig",
+                      "en": "adequate"
+                    },
+                    "lyhytNimi": {
+                      "fi": "5"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "TE",
+                  "nimi": {
+                    "fi": "Terveystieto",
+                    "sv": "Hälsokunskap",
+                    "en": "Health education"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Terveystieto",
+                    "sv": "Hälsokunskap"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 2,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "5",
+                    "nimi": {
+                      "fi": "välttävä",
+                      "sv": "försvarlig",
+                      "en": "adequate"
+                    },
+                    "lyhytNimi": {
+                      "fi": "5"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "KT",
+                  "nimi": {
+                    "fi": "Uskonto/Elämänkatsomustieto",
+                    "sv": "Religion/Livsåskådningskunskap",
+                    "en": "Religion/ethics"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Uskonto",
+                    "sv": "Religion"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 2,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "5",
+                    "nimi": {
+                      "fi": "välttävä",
+                      "sv": "försvarlig",
+                      "en": "adequate"
+                    },
+                    "lyhytNimi": {
+                      "fi": "5"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "HI",
+                  "nimi": {
+                    "fi": "Historia",
+                    "sv": "Historia",
+                    "en": "History"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Historia",
+                    "sv": "Historia"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 2,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "5",
+                    "nimi": {
+                      "fi": "välttävä",
+                      "sv": "försvarlig",
+                      "en": "adequate"
+                    },
+                    "lyhytNimi": {
+                      "fi": "5"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "YH",
+                  "nimi": {
+                    "fi": "Yhteiskuntaoppi",
+                    "sv": "Samhällslära",
+                    "en": "Social studies"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Yhteiskuntaoppi",
+                    "sv": "Samhällslära"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 2,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "5",
+                    "nimi": {
+                      "fi": "välttävä",
+                      "sv": "försvarlig",
+                      "en": "adequate"
+                    },
+                    "lyhytNimi": {
+                      "fi": "5"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "MU",
+                  "nimi": {
+                    "fi": "Musiikki",
+                    "sv": "Musik",
+                    "en": "Music"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Musiikki",
+                    "sv": "Musik"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 2,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "5",
+                    "nimi": {
+                      "fi": "välttävä",
+                      "sv": "försvarlig",
+                      "en": "adequate"
+                    },
+                    "lyhytNimi": {
+                      "fi": "5"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "KU",
+                  "nimi": {
+                    "fi": "Kuvataide",
+                    "sv": "Bildkonst",
+                    "en": "Visual arts"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Kuvataide",
+                    "sv": "Bildkonst"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 2,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "5",
+                    "nimi": {
+                      "fi": "välttävä",
+                      "sv": "försvarlig",
+                      "en": "adequate"
+                    },
+                    "lyhytNimi": {
+                      "fi": "5"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "KS",
+                  "nimi": {
+                    "fi": "Käsityö",
+                    "sv": "Slöjd",
+                    "en": "Crafts"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Käsityö",
+                    "sv": "Slöjd"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 2,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "5",
+                    "nimi": {
+                      "fi": "välttävä",
+                      "sv": "försvarlig",
+                      "en": "adequate"
+                    },
+                    "lyhytNimi": {
+                      "fi": "5"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LI",
+                  "nimi": {
+                    "fi": "Liikunta",
+                    "sv": "Gymnastik",
+                    "en": "Physical education"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Liikunta",
+                    "sv": "Gymnastik"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 2,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "5",
+                    "nimi": {
+                      "fi": "välttävä",
+                      "sv": "försvarlig",
+                      "en": "adequate"
+                    },
+                    "lyhytNimi": {
+                      "fi": "5"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "KO",
+                  "nimi": {
+                    "fi": "Kotitalous",
+                    "sv": "Huslig ekonomi",
+                    "en": "Home economics"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Kotitalous",
+                    "sv": "Huslig ekonomi"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 2,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "5",
+                    "nimi": {
+                      "fi": "välttävä",
+                      "sv": "försvarlig",
+                      "en": "adequate"
+                    },
+                    "lyhytNimi": {
+                      "fi": "5"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "OP",
+                  "nimi": {
+                    "fi": "Opinto-ohjaus",
+                    "sv": "Elevhandledning",
+                    "en": "Guidance counselling"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Opinto-ohjaus"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 2,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "5",
+                    "nimi": {
+                      "fi": "välttävä",
+                      "sv": "försvarlig",
+                      "en": "adequate"
+                    },
+                    "lyhytNimi": {
+                      "fi": "5"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            }
+          ],
+          "tyyppi": {
+            "koodiarvo": "perusopetuksenvuosiluokka",
+            "nimi": {
+              "fi": "Perusopetuksen vuosiluokka",
+              "sv": "Årskurs i grundläggande utbildning",
+              "en": "Basic education class"
+            },
+            "koodistoUri": "suorituksentyyppi",
+            "koodistoVersio": 1
+          }
+        }
+      ],
+      "tyyppi": {
+        "koodiarvo": "perusopetus",
+        "nimi": {
+          "fi": "Perusopetus",
+          "sv": "Grundläggande utbildning",
+          "en": "Basic education"
+        },
+        "lyhytNimi": {
+          "fi": "Perusopetus"
+        },
+        "koodistoUri": "opiskeluoikeudentyyppi",
+        "koodistoVersio": 1
+      },
+      "alkamispäivä": "2023-08-09"
+    }
+  ]
+}

--- a/src/test/scala/fi/vm/sade/hakurekisteri/integration/koski/json/koskidata_perusopetus_valmis_erityinen_jaanyt_9luokalle.json
+++ b/src/test/scala/fi/vm/sade/hakurekisteri/integration/koski/json/koskidata_perusopetus_valmis_erityinen_jaanyt_9luokalle.json
@@ -1,0 +1,3818 @@
+{
+  "henkilö": {
+    "oid": "1.2.246.562.24.46810818488",
+    "hetu": "011215A951V",
+    "syntymäaika": "2015-12-01",
+    "etunimet": "Nathan Testi",
+    "kutsumanimi": "Nathan",
+    "sukunimi": "Pajula-Testi",
+    "äidinkieli": {
+      "koodiarvo": "FI",
+      "nimi": {
+        "fi": "suomi",
+        "sv": "finska",
+        "en": "Finnish"
+      },
+      "lyhytNimi": {
+        "fi": "suomi",
+        "sv": "finska",
+        "en": "Finnish"
+      },
+      "koodistoUri": "kieli",
+      "koodistoVersio": 1
+    },
+    "kansalaisuus": [
+      {
+        "koodiarvo": "246",
+        "nimi": {
+          "fi": "Suomi",
+          "sv": "Finland",
+          "en": "Finland"
+        },
+        "lyhytNimi": {
+          "fi": "FI",
+          "sv": "FI",
+          "en": "FI"
+        },
+        "koodistoUri": "maatjavaltiot2",
+        "koodistoVersio": 2
+      }
+    ],
+    "turvakielto": false
+  },
+  "opiskeluoikeudet": [
+    {
+      "oid": "1.2.246.562.15.68047830226",
+      "versionumero": 3,
+      "aikaleima": "2024-02-12T10:49:41.264332",
+      "oppilaitos": {
+        "oid": "1.2.246.562.10.19666365424",
+        "oppilaitosnumero": {
+          "koodiarvo": "03244",
+          "nimi": {
+            "fi": "Länsi-Puijon koulu",
+            "sv": "Länsi-Puijon koulu",
+            "en": "Länsi-Puijon koulu"
+          },
+          "lyhytNimi": {
+            "fi": "Länsi-Puijon koulu",
+            "sv": "Länsi-Puijon koulu",
+            "en": "Länsi-Puijon koulu"
+          },
+          "koodistoUri": "oppilaitosnumero",
+          "koodistoVersio": 1
+        },
+        "nimi": {
+          "fi": "Länsi-Puijon koulu",
+          "sv": "Länsi-Puijon koulu",
+          "en": "Länsi-Puijon koulu"
+        },
+        "kotipaikka": {
+          "koodiarvo": "297",
+          "nimi": {
+            "fi": "Kuopio",
+            "sv": "Kuopio"
+          },
+          "koodistoUri": "kunta",
+          "koodistoVersio": 2
+        }
+      },
+      "koulutustoimija": {
+        "oid": "1.2.246.562.10.59286753021",
+        "nimi": {
+          "fi": "Kuopion kaupunki",
+          "sv": "Kuopion kaupunki",
+          "en": "Kuopion kaupunki"
+        },
+        "yTunnus": "0171450-7",
+        "kotipaikka": {
+          "koodiarvo": "297",
+          "nimi": {
+            "fi": "Kuopio",
+            "sv": "Kuopio"
+          },
+          "koodistoUri": "kunta",
+          "koodistoVersio": 2
+        }
+      },
+      "tila": {
+        "opiskeluoikeusjaksot": [
+          {
+            "alku": "2022-08-10",
+            "tila": {
+              "koodiarvo": "lasna",
+              "nimi": {
+                "fi": "Läsnä",
+                "sv": "Närvarande",
+                "en": "Present"
+              },
+              "koodistoUri": "koskiopiskeluoikeudentila",
+              "koodistoVersio": 1
+            }
+          },
+          {
+            "alku": "2022-12-20",
+            "tila": {
+              "koodiarvo": "loma",
+              "nimi": {
+                "fi": "Loma",
+                "sv": "Semester",
+                "en": "Vacation"
+              },
+              "koodistoUri": "koskiopiskeluoikeudentila",
+              "koodistoVersio": 1
+            }
+          },
+          {
+            "alku": "2023-01-07",
+            "tila": {
+              "koodiarvo": "lasna",
+              "nimi": {
+                "fi": "Läsnä",
+                "sv": "Närvarande",
+                "en": "Present"
+              },
+              "koodistoUri": "koskiopiskeluoikeudentila",
+              "koodistoVersio": 1
+            }
+          },
+          {
+            "alku": "2023-06-03",
+            "tila": {
+              "koodiarvo": "valmistunut",
+              "nimi": {
+                "fi": "Valmistunut",
+                "sv": "Utexaminerad",
+                "en": "Graduated"
+              },
+              "koodistoUri": "koskiopiskeluoikeudentila",
+              "koodistoVersio": 1
+            }
+          }
+        ]
+      },
+      "suoritukset": [
+        {
+          "koulutusmoduuli": {
+            "tunniste": {
+              "koodiarvo": "999905",
+              "nimi": {
+                "fi": "Perusopetukseen valmistava opetus",
+                "sv": "Undervisning som förebereder för den grundläggande utbildning"
+              },
+              "lyhytNimi": {
+                "fi": "Perusopetukseen valmistava opetus"
+              },
+              "koodistoUri": "koulutus",
+              "koodistoVersio": 12
+            },
+            "perusteenDiaarinumero": "57/011/2015",
+            "koulutustyyppi": {
+              "koodiarvo": "22",
+              "nimi": {
+                "fi": "Perusopetukseen valmistava opetus",
+                "sv": "Utbildning som förbereder för grundläggande utbildning"
+              },
+              "koodistoUri": "koulutustyyppi"
+            }
+          },
+          "toimipiste": {
+            "oid": "1.2.246.562.10.19666365424",
+            "oppilaitosnumero": {
+              "koodiarvo": "03244",
+              "nimi": {
+                "fi": "Länsi-Puijon koulu",
+                "sv": "Länsi-Puijon koulu",
+                "en": "Länsi-Puijon koulu"
+              },
+              "lyhytNimi": {
+                "fi": "Länsi-Puijon koulu",
+                "sv": "Länsi-Puijon koulu",
+                "en": "Länsi-Puijon koulu"
+              },
+              "koodistoUri": "oppilaitosnumero",
+              "koodistoVersio": 1
+            },
+            "nimi": {
+              "fi": "Länsi-Puijon koulu",
+              "sv": "Länsi-Puijon koulu",
+              "en": "Länsi-Puijon koulu"
+            },
+            "kotipaikka": {
+              "koodiarvo": "297",
+              "nimi": {
+                "fi": "Kuopio",
+                "sv": "Kuopio"
+              },
+              "koodistoUri": "kunta",
+              "koodistoVersio": 2
+            }
+          },
+          "vahvistus": {
+            "päivä": "2023-06-03",
+            "paikkakunta": {
+              "koodiarvo": "297",
+              "nimi": {
+                "fi": "Kuopio",
+                "sv": "Kuopio"
+              },
+              "koodistoUri": "kunta",
+              "koodistoVersio": 2
+            },
+            "myöntäjäOrganisaatio": {
+              "oid": "1.2.246.562.10.19666365424",
+              "oppilaitosnumero": {
+                "koodiarvo": "03244",
+                "nimi": {
+                  "fi": "Länsi-Puijon koulu",
+                  "sv": "Länsi-Puijon koulu",
+                  "en": "Länsi-Puijon koulu"
+                },
+                "lyhytNimi": {
+                  "fi": "Länsi-Puijon koulu",
+                  "sv": "Länsi-Puijon koulu",
+                  "en": "Länsi-Puijon koulu"
+                },
+                "koodistoUri": "oppilaitosnumero",
+                "koodistoVersio": 1
+              },
+              "nimi": {
+                "fi": "Länsi-Puijon koulu",
+                "sv": "Länsi-Puijon koulu",
+                "en": "Länsi-Puijon koulu"
+              },
+              "kotipaikka": {
+                "koodiarvo": "297",
+                "nimi": {
+                  "fi": "Kuopio",
+                  "sv": "Kuopio"
+                },
+                "koodistoUri": "kunta",
+                "koodistoVersio": 2
+              }
+            },
+            "myöntäjäHenkilöt": [
+              {
+                "nimi": "Reijo Reksi",
+                "titteli": {
+                  "fi": "Rehtori"
+                },
+                "organisaatio": {
+                  "oid": "1.2.246.562.10.19666365424",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "03244",
+                    "nimi": {
+                      "fi": "Länsi-Puijon koulu",
+                      "sv": "Länsi-Puijon koulu",
+                      "en": "Länsi-Puijon koulu"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Länsi-Puijon koulu",
+                      "sv": "Länsi-Puijon koulu",
+                      "en": "Länsi-Puijon koulu"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Länsi-Puijon koulu",
+                    "sv": "Länsi-Puijon koulu",
+                    "en": "Länsi-Puijon koulu"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "297",
+                    "nimi": {
+                      "fi": "Kuopio",
+                      "sv": "Kuopio"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              }
+            ]
+          },
+          "suorituskieli": {
+            "koodiarvo": "FI",
+            "nimi": {
+              "fi": "suomi",
+              "sv": "finska",
+              "en": "Finnish"
+            },
+            "lyhytNimi": {
+              "fi": "suomi",
+              "sv": "finska",
+              "en": "Finnish"
+            },
+            "koodistoUri": "kieli",
+            "koodistoVersio": 1
+          },
+          "omanÄidinkielenOpinnot": {
+            "arvosana": {
+              "koodiarvo": "O",
+              "nimi": {
+                "fi": "osallistunut",
+                "sv": "deltagit",
+                "en": "participated"
+              },
+              "lyhytNimi": {
+                "fi": "O"
+              },
+              "koodistoUri": "arviointiasteikkoyleissivistava",
+              "koodistoVersio": 1
+            },
+            "arviointipäivä": "2023-06-01",
+            "kieli": {
+              "koodiarvo": "AF",
+              "nimi": {
+                "fi": "afrikaans",
+                "sv": "afrikaans",
+                "en": "afrikaans"
+              },
+              "lyhytNimi": {
+                "fi": "afrikaans",
+                "sv": "afrikaans",
+                "en": "Afrikaans"
+              },
+              "koodistoUri": "kielivalikoima",
+              "koodistoVersio": 1
+            },
+            "laajuus": {
+              "arvo": 2,
+              "yksikkö": {
+                "koodiarvo": "3",
+                "nimi": {
+                  "fi": "vuosiviikkotuntia",
+                  "sv": "årsveckotimmar",
+                  "en": "weekly lessons per year"
+                },
+                "lyhytNimi": {
+                  "fi": "vuosiviikkotuntia",
+                  "sv": "årsveckotimmar",
+                  "en": "weekly lessons per year"
+                },
+                "koodistoUri": "opintojenlaajuusyksikko",
+                "koodistoVersio": 1
+              }
+            },
+            "hyväksytty": false
+          },
+          "osasuoritukset": [
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "S2",
+                  "nimi": {
+                    "fi": "Suomi toisena kielenä ja kirjallisuus"
+                  }
+                },
+                "laajuus": {
+                  "arvo": 4,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "O",
+                    "nimi": {
+                      "fi": "osallistunut",
+                      "sv": "deltagit",
+                      "en": "participated"
+                    },
+                    "lyhytNimi": {
+                      "fi": "O"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": false
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetukseenvalmistavanopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetukseen valmistavan opetuksen oppiaine",
+                  "sv": "Läroämne i förberedande undervisning för grundläggande utbildning",
+                  "en": "Instruction preparing for basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "maa",
+                  "nimi": {
+                    "fi": "Matematiikka"
+                  }
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "O",
+                    "nimi": {
+                      "fi": "osallistunut",
+                      "sv": "deltagit",
+                      "en": "participated"
+                    },
+                    "lyhytNimi": {
+                      "fi": "O"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": false
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetukseenvalmistavanopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetukseen valmistavan opetuksen oppiaine",
+                  "sv": "Läroämne i förberedande undervisning för grundläggande utbildning",
+                  "en": "Instruction preparing for basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "MA",
+                  "nimi": {
+                    "fi": "Matematiikka",
+                    "sv": "Matematik",
+                    "en": "Mathematics"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Matematiikka",
+                    "sv": "Matematik"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": false,
+                "laajuus": {
+                  "arvo": 3,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "10",
+                    "nimi": {
+                      "fi": "erinomainen",
+                      "sv": "utmärkt",
+                      "en": "excellent"
+                    },
+                    "lyhytNimi": {
+                      "fi": "10"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "luokkaAste": {
+                "koodiarvo": "4",
+                "nimi": {
+                  "fi": "4. vuosiluokka",
+                  "sv": "Årskurs 4",
+                  "en": "4th grade"
+                },
+                "koodistoUri": "perusopetuksenluokkaaste",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaineperusopetukseenvalmistavassaopetuksessa",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine perusopetukseen valmistavassa opetuksessa",
+                  "sv": "Studier i ett läroämne i grundläggande utbildning som är del av förberedande undervisning för grundläggande utbildning"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              },
+              "suoritustapa": {
+                "koodiarvo": "erityinentutkinto",
+                "nimi": {
+                  "fi": "Erityinen tutkinto",
+                  "sv": "Särskild examen",
+                  "en": "Separate basic education examination"
+                },
+                "koodistoUri": "perusopetuksensuoritustapa",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "MA",
+                  "nimi": {
+                    "fi": "Matematiikka",
+                    "sv": "Matematik",
+                    "en": "Mathematics"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Matematiikka",
+                    "sv": "Matematik"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": false,
+                "laajuus": {
+                  "arvo": 3,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "10",
+                    "nimi": {
+                      "fi": "erinomainen",
+                      "sv": "utmärkt",
+                      "en": "excellent"
+                    },
+                    "lyhytNimi": {
+                      "fi": "10"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "luokkaAste": {
+                "koodiarvo": "5",
+                "nimi": {
+                  "fi": "5. vuosiluokka",
+                  "sv": "Årskurs 5",
+                  "en": "5th grade"
+                },
+                "koodistoUri": "perusopetuksenluokkaaste",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaineperusopetukseenvalmistavassaopetuksessa",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine perusopetukseen valmistavassa opetuksessa",
+                  "sv": "Studier i ett läroämne i grundläggande utbildning som är del av förberedande undervisning för grundläggande utbildning"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              },
+              "suoritustapa": {
+                "koodiarvo": "erityinentutkinto",
+                "nimi": {
+                  "fi": "Erityinen tutkinto",
+                  "sv": "Särskild examen",
+                  "en": "Separate basic education examination"
+                },
+                "koodistoUri": "perusopetuksensuoritustapa",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "A1",
+                  "nimi": {
+                    "fi": "A1-kieli",
+                    "sv": "A1-språk",
+                    "en": "A1-language"
+                  },
+                  "lyhytNimi": {
+                    "fi": "A1-kieli",
+                    "sv": "A1-språk"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "kieli": {
+                  "koodiarvo": "EN",
+                  "nimi": {
+                    "fi": "englanti",
+                    "sv": "engelska",
+                    "en": "English"
+                  },
+                  "lyhytNimi": {
+                    "fi": "englanti",
+                    "sv": "engelska",
+                    "en": "English"
+                  },
+                  "koodistoUri": "kielivalikoima",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": false,
+                "laajuus": {
+                  "arvo": 2,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "9",
+                    "nimi": {
+                      "fi": "kiitettävä",
+                      "sv": "berömlig",
+                      "en": "excellent"
+                    },
+                    "lyhytNimi": {
+                      "fi": "9"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "luokkaAste": {
+                "koodiarvo": "4",
+                "nimi": {
+                  "fi": "4. vuosiluokka",
+                  "sv": "Årskurs 4",
+                  "en": "4th grade"
+                },
+                "koodistoUri": "perusopetuksenluokkaaste",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaineperusopetukseenvalmistavassaopetuksessa",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine perusopetukseen valmistavassa opetuksessa",
+                  "sv": "Studier i ett läroämne i grundläggande utbildning som är del av förberedande undervisning för grundläggande utbildning"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              },
+              "suoritustapa": {
+                "koodiarvo": "erityinentutkinto",
+                "nimi": {
+                  "fi": "Erityinen tutkinto",
+                  "sv": "Särskild examen",
+                  "en": "Separate basic education examination"
+                },
+                "koodistoUri": "perusopetuksensuoritustapa",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "AI",
+                  "nimi": {
+                    "fi": "Äidinkieli ja kirjallisuus",
+                    "sv": "Modersmålet och litteratur",
+                    "en": "Mother tongue and literature"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Äidinkieli ja kirjallisuus",
+                    "sv": "Modersmålet och litteratur"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "kieli": {
+                  "koodiarvo": "AI7",
+                  "nimi": {
+                    "fi": "Suomi toisena kielenä ja kirjallisuus",
+                    "sv": "Finska som andraspråk och litteratur",
+                    "en": "Finnish as a second language and literature"
+                  },
+                  "koodistoUri": "oppiaineaidinkielijakirjallisuus",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": false,
+                "laajuus": {
+                  "arvo": 4,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "7",
+                    "nimi": {
+                      "fi": "tyydyttävä",
+                      "sv": "nöjaktig",
+                      "en": "satisfactory"
+                    },
+                    "lyhytNimi": {
+                      "fi": "7"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "luokkaAste": {
+                "koodiarvo": "4",
+                "nimi": {
+                  "fi": "4. vuosiluokka",
+                  "sv": "Årskurs 4",
+                  "en": "4th grade"
+                },
+                "koodistoUri": "perusopetuksenluokkaaste",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaineperusopetukseenvalmistavassaopetuksessa",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine perusopetukseen valmistavassa opetuksessa",
+                  "sv": "Studier i ett läroämne i grundläggande utbildning som är del av förberedande undervisning för grundläggande utbildning"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              },
+              "suoritustapa": {
+                "koodiarvo": "erityinentutkinto",
+                "nimi": {
+                  "fi": "Erityinen tutkinto",
+                  "sv": "Särskild examen",
+                  "en": "Separate basic education examination"
+                },
+                "koodistoUri": "perusopetuksensuoritustapa",
+                "koodistoVersio": 1
+              }
+            }
+          ],
+          "kokonaislaajuus": {
+            "arvo": 1000,
+            "yksikkö": {
+              "koodiarvo": "3",
+              "nimi": {
+                "fi": "vuosiviikkotuntia",
+                "sv": "årsveckotimmar",
+                "en": "weekly lessons per year"
+              },
+              "lyhytNimi": {
+                "fi": "vuosiviikkotuntia",
+                "sv": "årsveckotimmar",
+                "en": "weekly lessons per year"
+              },
+              "koodistoUri": "opintojenlaajuusyksikko",
+              "koodistoVersio": 1
+            }
+          },
+          "tyyppi": {
+            "koodiarvo": "perusopetukseenvalmistavaopetus",
+            "nimi": {
+              "fi": "Perusopetukseen valmistava opetus",
+              "sv": "Förberedande undervisning för grundläggande utbildning",
+              "en": "Instruction preparing for basic education"
+            },
+            "koodistoUri": "suorituksentyyppi",
+            "koodistoVersio": 1
+          }
+        }
+      ],
+      "tyyppi": {
+        "koodiarvo": "perusopetukseenvalmistavaopetus",
+        "nimi": {
+          "fi": "Perusopetukseen valmistava opetus",
+          "sv": "Förberedande undervisning för den grundläggande utbildningen",
+          "en": "Instruction preparing for basic education"
+        },
+        "lyhytNimi": {
+          "fi": "Perusopetukseen valmistava opetus"
+        },
+        "koodistoUri": "opiskeluoikeudentyyppi",
+        "koodistoVersio": 1
+      },
+      "alkamispäivä": "2022-08-10",
+      "päättymispäivä": "2023-06-03"
+    },
+    {
+      "oid": "1.2.246.562.15.44381164167",
+      "versionumero": 17,
+      "aikaleima": "2024-05-14T12:57:23.918626",
+      "oppilaitos": {
+        "oid": "1.2.246.562.10.19666365424",
+        "oppilaitosnumero": {
+          "koodiarvo": "03244",
+          "nimi": {
+            "fi": "Länsi-Puijon koulu",
+            "sv": "Länsi-Puijon koulu",
+            "en": "Länsi-Puijon koulu"
+          },
+          "lyhytNimi": {
+            "fi": "Länsi-Puijon koulu",
+            "sv": "Länsi-Puijon koulu",
+            "en": "Länsi-Puijon koulu"
+          },
+          "koodistoUri": "oppilaitosnumero",
+          "koodistoVersio": 1
+        },
+        "nimi": {
+          "fi": "Länsi-Puijon koulu",
+          "sv": "Länsi-Puijon koulu",
+          "en": "Länsi-Puijon koulu"
+        },
+        "kotipaikka": {
+          "koodiarvo": "297",
+          "nimi": {
+            "fi": "Kuopio",
+            "sv": "Kuopio"
+          },
+          "koodistoUri": "kunta",
+          "koodistoVersio": 2
+        }
+      },
+      "koulutustoimija": {
+        "oid": "1.2.246.562.10.59286753021",
+        "nimi": {
+          "fi": "Kuopion kaupunki",
+          "sv": "Kuopion kaupunki",
+          "en": "Kuopion kaupunki"
+        },
+        "yTunnus": "0171450-7",
+        "kotipaikka": {
+          "koodiarvo": "297",
+          "nimi": {
+            "fi": "Kuopio",
+            "sv": "Kuopio"
+          },
+          "koodistoUri": "kunta",
+          "koodistoVersio": 2
+        }
+      },
+      "tila": {
+        "opiskeluoikeusjaksot": [
+          {
+            "alku": "2023-08-10",
+            "tila": {
+              "koodiarvo": "lasna",
+              "nimi": {
+                "fi": "Läsnä",
+                "sv": "Närvarande",
+                "en": "Present"
+              },
+              "koodistoUri": "koskiopiskeluoikeudentila",
+              "koodistoVersio": 1
+            }
+          },
+          {
+            "alku": "2024-05-14",
+            "tila": {
+              "koodiarvo": "valmistunut",
+              "nimi": {
+                "fi": "Valmistunut",
+                "sv": "Utexaminerad",
+                "en": "Graduated"
+              },
+              "koodistoUri": "koskiopiskeluoikeudentila",
+              "koodistoVersio": 1
+            }
+          }
+        ]
+      },
+      "suoritukset": [
+        {
+          "koulutusmoduuli": {
+            "perusteenDiaarinumero": "104/011/2014",
+            "tunniste": {
+              "koodiarvo": "201101",
+              "nimi": {
+                "fi": "Perusopetus",
+                "sv": "Grundläggande utbildning",
+                "en": "Basic education"
+              },
+              "koodistoUri": "koulutus",
+              "koodistoVersio": 12
+            },
+            "koulutustyyppi": {
+              "koodiarvo": "16",
+              "nimi": {
+                "fi": "Perusopetus",
+                "sv": "Grundläggande utbildning"
+              },
+              "lyhytNimi": {
+                "fi": "Perusopetus",
+                "sv": "Grundläggande utbildning"
+              },
+              "koodistoUri": "koulutustyyppi"
+            }
+          },
+          "toimipiste": {
+            "oid": "1.2.246.562.10.19666365424",
+            "oppilaitosnumero": {
+              "koodiarvo": "03244",
+              "nimi": {
+                "fi": "Länsi-Puijon koulu",
+                "sv": "Länsi-Puijon koulu",
+                "en": "Länsi-Puijon koulu"
+              },
+              "lyhytNimi": {
+                "fi": "Länsi-Puijon koulu",
+                "sv": "Länsi-Puijon koulu",
+                "en": "Länsi-Puijon koulu"
+              },
+              "koodistoUri": "oppilaitosnumero",
+              "koodistoVersio": 1
+            },
+            "nimi": {
+              "fi": "Länsi-Puijon koulu",
+              "sv": "Länsi-Puijon koulu",
+              "en": "Länsi-Puijon koulu"
+            },
+            "kotipaikka": {
+              "koodiarvo": "297",
+              "nimi": {
+                "fi": "Kuopio",
+                "sv": "Kuopio"
+              },
+              "koodistoUri": "kunta",
+              "koodistoVersio": 2
+            }
+          },
+          "vahvistus": {
+            "päivä": "2024-05-14",
+            "paikkakunta": {
+              "koodiarvo": "297",
+              "nimi": {
+                "fi": "Kuopio",
+                "sv": "Kuopio"
+              },
+              "koodistoUri": "kunta",
+              "koodistoVersio": 2
+            },
+            "myöntäjäOrganisaatio": {
+              "oid": "1.2.246.562.10.19666365424",
+              "oppilaitosnumero": {
+                "koodiarvo": "03244",
+                "nimi": {
+                  "fi": "Länsi-Puijon koulu",
+                  "sv": "Länsi-Puijon koulu",
+                  "en": "Länsi-Puijon koulu"
+                },
+                "lyhytNimi": {
+                  "fi": "Länsi-Puijon koulu",
+                  "sv": "Länsi-Puijon koulu",
+                  "en": "Länsi-Puijon koulu"
+                },
+                "koodistoUri": "oppilaitosnumero",
+                "koodistoVersio": 1
+              },
+              "nimi": {
+                "fi": "Länsi-Puijon koulu",
+                "sv": "Länsi-Puijon koulu",
+                "en": "Länsi-Puijon koulu"
+              },
+              "kotipaikka": {
+                "koodiarvo": "297",
+                "nimi": {
+                  "fi": "Kuopio",
+                  "sv": "Kuopio"
+                },
+                "koodistoUri": "kunta",
+                "koodistoVersio": 2
+              }
+            },
+            "myöntäjäHenkilöt": [
+              {
+                "nimi": "Reijo Reksi",
+                "titteli": {
+                  "fi": "Rehtori"
+                },
+                "organisaatio": {
+                  "oid": "1.2.246.562.10.19666365424",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "03244",
+                    "nimi": {
+                      "fi": "Länsi-Puijon koulu",
+                      "sv": "Länsi-Puijon koulu",
+                      "en": "Länsi-Puijon koulu"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Länsi-Puijon koulu",
+                      "sv": "Länsi-Puijon koulu",
+                      "en": "Länsi-Puijon koulu"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Länsi-Puijon koulu",
+                    "sv": "Länsi-Puijon koulu",
+                    "en": "Länsi-Puijon koulu"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "297",
+                    "nimi": {
+                      "fi": "Kuopio",
+                      "sv": "Kuopio"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              }
+            ]
+          },
+          "suoritustapa": {
+            "koodiarvo": "erityinentutkinto",
+            "nimi": {
+              "fi": "Erityinen tutkinto",
+              "sv": "Särskild examen",
+              "en": "Separate basic education examination"
+            },
+            "koodistoUri": "perusopetuksensuoritustapa",
+            "koodistoVersio": 1
+          },
+          "suorituskieli": {
+            "koodiarvo": "FI",
+            "nimi": {
+              "fi": "suomi",
+              "sv": "finska",
+              "en": "Finnish"
+            },
+            "lyhytNimi": {
+              "fi": "suomi",
+              "sv": "finska",
+              "en": "Finnish"
+            },
+            "koodistoUri": "kieli",
+            "koodistoVersio": 1
+          },
+          "osasuoritukset": [
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "AI",
+                  "nimi": {
+                    "fi": "Äidinkieli ja kirjallisuus",
+                    "sv": "Modersmålet och litteratur",
+                    "en": "Mother tongue and literature"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Äidinkieli ja kirjallisuus",
+                    "sv": "Modersmålet och litteratur"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "kieli": {
+                  "koodiarvo": "AI1",
+                  "nimi": {
+                    "fi": "Suomen kieli ja kirjallisuus",
+                    "sv": "Finska och litteratur",
+                    "en": "Finnish language and literature"
+                  },
+                  "koodistoUri": "oppiaineaidinkielijakirjallisuus",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 10,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "7",
+                    "nimi": {
+                      "fi": "tyydyttävä",
+                      "sv": "nöjaktig",
+                      "en": "satisfactory"
+                    },
+                    "lyhytNimi": {
+                      "fi": "7"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "A1",
+                  "nimi": {
+                    "fi": "A1-kieli",
+                    "sv": "A1-språk",
+                    "en": "A1-language"
+                  },
+                  "lyhytNimi": {
+                    "fi": "A1-kieli",
+                    "sv": "A1-språk"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "kieli": {
+                  "koodiarvo": "EN",
+                  "nimi": {
+                    "fi": "englanti",
+                    "sv": "engelska",
+                    "en": "English"
+                  },
+                  "lyhytNimi": {
+                    "fi": "englanti",
+                    "sv": "engelska",
+                    "en": "English"
+                  },
+                  "koodistoUri": "kielivalikoima",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 8,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "6",
+                    "nimi": {
+                      "fi": "kohtalainen",
+                      "sv": "hjälplig",
+                      "en": "moderate"
+                    },
+                    "lyhytNimi": {
+                      "fi": "6"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "B1",
+                  "nimi": {
+                    "fi": "B1-kieli",
+                    "sv": "B1-språk",
+                    "en": "B1-language"
+                  },
+                  "lyhytNimi": {
+                    "fi": "B1-kieli",
+                    "sv": "B1-språk"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "kieli": {
+                  "koodiarvo": "SV",
+                  "nimi": {
+                    "fi": "ruotsi",
+                    "sv": "svenska",
+                    "en": "Swedish"
+                  },
+                  "lyhytNimi": {
+                    "fi": "ruotsi",
+                    "sv": "svenska",
+                    "en": "Swedish"
+                  },
+                  "koodistoUri": "kielivalikoima",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 6,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "6",
+                    "nimi": {
+                      "fi": "kohtalainen",
+                      "sv": "hjälplig",
+                      "en": "moderate"
+                    },
+                    "lyhytNimi": {
+                      "fi": "6"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "MA",
+                  "nimi": {
+                    "fi": "Matematiikka",
+                    "sv": "Matematik",
+                    "en": "Mathematics"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Matematiikka",
+                    "sv": "Matematik"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 4,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "8",
+                    "nimi": {
+                      "fi": "hyvä",
+                      "sv": "god",
+                      "en": "good"
+                    },
+                    "lyhytNimi": {
+                      "fi": "8"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "BI",
+                  "nimi": {
+                    "fi": "Biologia",
+                    "sv": "Biologi",
+                    "en": "Biology"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Biologia",
+                    "sv": "Biologi"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 4,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "6",
+                    "nimi": {
+                      "fi": "kohtalainen",
+                      "sv": "hjälplig",
+                      "en": "moderate"
+                    },
+                    "lyhytNimi": {
+                      "fi": "6"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "GE",
+                  "nimi": {
+                    "fi": "Maantieto",
+                    "sv": "Geografi",
+                    "en": "Geography"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Maantieto",
+                    "sv": "Geografi"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 4,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "6",
+                    "nimi": {
+                      "fi": "kohtalainen",
+                      "sv": "hjälplig",
+                      "en": "moderate"
+                    },
+                    "lyhytNimi": {
+                      "fi": "6"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "FY",
+                  "nimi": {
+                    "fi": "Fysiikka",
+                    "sv": "Fysik",
+                    "en": "Physics"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Fysiikka",
+                    "sv": "Fysik"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 4,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "7",
+                    "nimi": {
+                      "fi": "tyydyttävä",
+                      "sv": "nöjaktig",
+                      "en": "satisfactory"
+                    },
+                    "lyhytNimi": {
+                      "fi": "7"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "KE",
+                  "nimi": {
+                    "fi": "Kemia",
+                    "sv": "Kemi",
+                    "en": "Chemistry"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Kemia",
+                    "sv": "Kemi"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 4,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "7",
+                    "nimi": {
+                      "fi": "tyydyttävä",
+                      "sv": "nöjaktig",
+                      "en": "satisfactory"
+                    },
+                    "lyhytNimi": {
+                      "fi": "7"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "TE",
+                  "nimi": {
+                    "fi": "Terveystieto",
+                    "sv": "Hälsokunskap",
+                    "en": "Health education"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Terveystieto",
+                    "sv": "Hälsokunskap"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 4,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "6",
+                    "nimi": {
+                      "fi": "kohtalainen",
+                      "sv": "hjälplig",
+                      "en": "moderate"
+                    },
+                    "lyhytNimi": {
+                      "fi": "6"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "ET",
+                  "nimi": {
+                    "fi": "Uskonto/Elämänkatsomustieto",
+                    "sv": "Religion/Livsåskådningskunskap",
+                    "en": "Religion/ethics"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Elämänkatsomustieto",
+                    "sv": "Livsåskådningskunskap"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 4,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "5",
+                    "nimi": {
+                      "fi": "välttävä",
+                      "sv": "försvarlig",
+                      "en": "adequate"
+                    },
+                    "lyhytNimi": {
+                      "fi": "5"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "HI",
+                  "nimi": {
+                    "fi": "Historia",
+                    "sv": "Historia",
+                    "en": "History"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Historia",
+                    "sv": "Historia"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 4,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "6",
+                    "nimi": {
+                      "fi": "kohtalainen",
+                      "sv": "hjälplig",
+                      "en": "moderate"
+                    },
+                    "lyhytNimi": {
+                      "fi": "6"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "YH",
+                  "nimi": {
+                    "fi": "Yhteiskuntaoppi",
+                    "sv": "Samhällslära",
+                    "en": "Social studies"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Yhteiskuntaoppi",
+                    "sv": "Samhällslära"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 2,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "7",
+                    "nimi": {
+                      "fi": "tyydyttävä",
+                      "sv": "nöjaktig",
+                      "en": "satisfactory"
+                    },
+                    "lyhytNimi": {
+                      "fi": "7"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "MU",
+                  "nimi": {
+                    "fi": "Musiikki",
+                    "sv": "Musik",
+                    "en": "Music"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Musiikki",
+                    "sv": "Musik"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 2,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "8",
+                    "nimi": {
+                      "fi": "hyvä",
+                      "sv": "god",
+                      "en": "good"
+                    },
+                    "lyhytNimi": {
+                      "fi": "8"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "KU",
+                  "nimi": {
+                    "fi": "Kuvataide",
+                    "sv": "Bildkonst",
+                    "en": "Visual arts"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Kuvataide",
+                    "sv": "Bildkonst"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 2,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "6",
+                    "nimi": {
+                      "fi": "kohtalainen",
+                      "sv": "hjälplig",
+                      "en": "moderate"
+                    },
+                    "lyhytNimi": {
+                      "fi": "6"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LI",
+                  "nimi": {
+                    "fi": "Liikunta",
+                    "sv": "Gymnastik",
+                    "en": "Physical education"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Liikunta",
+                    "sv": "Gymnastik"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 2,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "9",
+                    "nimi": {
+                      "fi": "kiitettävä",
+                      "sv": "berömlig",
+                      "en": "excellent"
+                    },
+                    "lyhytNimi": {
+                      "fi": "9"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "KS",
+                  "nimi": {
+                    "fi": "Käsityö",
+                    "sv": "Slöjd",
+                    "en": "Crafts"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Käsityö",
+                    "sv": "Slöjd"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 2,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "7",
+                    "nimi": {
+                      "fi": "tyydyttävä",
+                      "sv": "nöjaktig",
+                      "en": "satisfactory"
+                    },
+                    "lyhytNimi": {
+                      "fi": "7"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "KO",
+                  "nimi": {
+                    "fi": "Kotitalous",
+                    "sv": "Huslig ekonomi",
+                    "en": "Home economics"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Kotitalous",
+                    "sv": "Huslig ekonomi"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 2,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "8",
+                    "nimi": {
+                      "fi": "hyvä",
+                      "sv": "god",
+                      "en": "good"
+                    },
+                    "lyhytNimi": {
+                      "fi": "8"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "OP",
+                  "nimi": {
+                    "fi": "Opinto-ohjaus",
+                    "sv": "Elevhandledning",
+                    "en": "Guidance counselling"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Opinto-ohjaus"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 1,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "S",
+                    "nimi": {
+                      "fi": "hyväksytty",
+                      "sv": "godkänd",
+                      "en": "pass"
+                    },
+                    "lyhytNimi": {
+                      "fi": "S"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            }
+          ],
+          "tyyppi": {
+            "koodiarvo": "perusopetuksenoppimaara",
+            "nimi": {
+              "fi": "Perusopetuksen oppimäärä",
+              "sv": "Grundläggande utbildningens lärokurs",
+              "en": "Basic education syllabus"
+            },
+            "koodistoUri": "suorituksentyyppi",
+            "koodistoVersio": 1
+          },
+          "koulusivistyskieli": [
+            {
+              "koodiarvo": "FI",
+              "nimi": {
+                "fi": "suomi"
+              },
+              "koodistoUri": "kieli"
+            }
+          ]
+        },
+        {
+          "koulutusmoduuli": {
+            "tunniste": {
+              "koodiarvo": "9",
+              "nimi": {
+                "fi": "9. vuosiluokka",
+                "sv": "Årskurs 9",
+                "en": "9th grade"
+              },
+              "koodistoUri": "perusopetuksenluokkaaste",
+              "koodistoVersio": 1
+            },
+            "perusteenDiaarinumero": "104/011/2014",
+            "koulutustyyppi": {
+              "koodiarvo": "16",
+              "nimi": {
+                "fi": "Perusopetus",
+                "sv": "Grundläggande utbildning"
+              },
+              "lyhytNimi": {
+                "fi": "Perusopetus",
+                "sv": "Grundläggande utbildning"
+              },
+              "koodistoUri": "koulutustyyppi"
+            }
+          },
+          "luokka": "9A",
+          "toimipiste": {
+            "oid": "1.2.246.562.10.19666365424",
+            "oppilaitosnumero": {
+              "koodiarvo": "03244",
+              "nimi": {
+                "fi": "Länsi-Puijon koulu",
+                "sv": "Länsi-Puijon koulu",
+                "en": "Länsi-Puijon koulu"
+              },
+              "lyhytNimi": {
+                "fi": "Länsi-Puijon koulu",
+                "sv": "Länsi-Puijon koulu",
+                "en": "Länsi-Puijon koulu"
+              },
+              "koodistoUri": "oppilaitosnumero",
+              "koodistoVersio": 1
+            },
+            "nimi": {
+              "fi": "Länsi-Puijon koulu",
+              "sv": "Länsi-Puijon koulu",
+              "en": "Länsi-Puijon koulu"
+            },
+            "kotipaikka": {
+              "koodiarvo": "297",
+              "nimi": {
+                "fi": "Kuopio",
+                "sv": "Kuopio"
+              },
+              "koodistoUri": "kunta",
+              "koodistoVersio": 2
+            }
+          },
+          "alkamispäivä": "2023-08-10",
+          "vahvistus": {
+            "päivä": "2024-02-02",
+            "paikkakunta": {
+              "koodiarvo": "297",
+              "nimi": {
+                "fi": "Kuopio",
+                "sv": "Kuopio"
+              },
+              "koodistoUri": "kunta",
+              "koodistoVersio": 2
+            },
+            "myöntäjäOrganisaatio": {
+              "oid": "1.2.246.562.10.19666365424",
+              "oppilaitosnumero": {
+                "koodiarvo": "03244",
+                "nimi": {
+                  "fi": "Länsi-Puijon koulu",
+                  "sv": "Länsi-Puijon koulu",
+                  "en": "Länsi-Puijon koulu"
+                },
+                "lyhytNimi": {
+                  "fi": "Länsi-Puijon koulu",
+                  "sv": "Länsi-Puijon koulu",
+                  "en": "Länsi-Puijon koulu"
+                },
+                "koodistoUri": "oppilaitosnumero",
+                "koodistoVersio": 1
+              },
+              "nimi": {
+                "fi": "Länsi-Puijon koulu",
+                "sv": "Länsi-Puijon koulu",
+                "en": "Länsi-Puijon koulu"
+              },
+              "kotipaikka": {
+                "koodiarvo": "297",
+                "nimi": {
+                  "fi": "Kuopio",
+                  "sv": "Kuopio"
+                },
+                "koodistoUri": "kunta",
+                "koodistoVersio": 2
+              }
+            },
+            "myöntäjäHenkilöt": [
+              {
+                "nimi": "Reijo Reksi",
+                "titteli": {
+                  "fi": "Rehtori"
+                },
+                "organisaatio": {
+                  "oid": "1.2.246.562.10.19666365424",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "03244",
+                    "nimi": {
+                      "fi": "Länsi-Puijon koulu",
+                      "sv": "Länsi-Puijon koulu",
+                      "en": "Länsi-Puijon koulu"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Länsi-Puijon koulu",
+                      "sv": "Länsi-Puijon koulu",
+                      "en": "Länsi-Puijon koulu"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Länsi-Puijon koulu",
+                    "sv": "Länsi-Puijon koulu",
+                    "en": "Länsi-Puijon koulu"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "297",
+                    "nimi": {
+                      "fi": "Kuopio",
+                      "sv": "Kuopio"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              }
+            ]
+          },
+          "suorituskieli": {
+            "koodiarvo": "FI",
+            "nimi": {
+              "fi": "suomi",
+              "sv": "finska",
+              "en": "Finnish"
+            },
+            "lyhytNimi": {
+              "fi": "suomi",
+              "sv": "finska",
+              "en": "Finnish"
+            },
+            "koodistoUri": "kieli",
+            "koodistoVersio": 1
+          },
+          "jääLuokalle": true,
+          "osasuoritukset": [
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "AI",
+                  "nimi": {
+                    "fi": "Äidinkieli ja kirjallisuus",
+                    "sv": "Modersmålet och litteratur",
+                    "en": "Mother tongue and literature"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Äidinkieli ja kirjallisuus",
+                    "sv": "Modersmålet och litteratur"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "kieli": {
+                  "koodiarvo": "AI1",
+                  "nimi": {
+                    "fi": "Suomen kieli ja kirjallisuus",
+                    "sv": "Finska och litteratur",
+                    "en": "Finnish language and literature"
+                  },
+                  "koodistoUri": "oppiaineaidinkielijakirjallisuus",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 10,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "4",
+                    "nimi": {
+                      "fi": "hylätty",
+                      "sv": "underkänd",
+                      "en": "fail"
+                    },
+                    "lyhytNimi": {
+                      "fi": "4"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": false
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "A1",
+                  "nimi": {
+                    "fi": "A1-kieli",
+                    "sv": "A1-språk",
+                    "en": "A1-language"
+                  },
+                  "lyhytNimi": {
+                    "fi": "A1-kieli",
+                    "sv": "A1-språk"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "kieli": {
+                  "koodiarvo": "EN",
+                  "nimi": {
+                    "fi": "englanti",
+                    "sv": "engelska",
+                    "en": "English"
+                  },
+                  "lyhytNimi": {
+                    "fi": "englanti",
+                    "sv": "engelska",
+                    "en": "English"
+                  },
+                  "koodistoUri": "kielivalikoima",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 8,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "4",
+                    "nimi": {
+                      "fi": "hylätty",
+                      "sv": "underkänd",
+                      "en": "fail"
+                    },
+                    "lyhytNimi": {
+                      "fi": "4"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": false
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "B1",
+                  "nimi": {
+                    "fi": "B1-kieli",
+                    "sv": "B1-språk",
+                    "en": "B1-language"
+                  },
+                  "lyhytNimi": {
+                    "fi": "B1-kieli",
+                    "sv": "B1-språk"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "kieli": {
+                  "koodiarvo": "SV",
+                  "nimi": {
+                    "fi": "ruotsi",
+                    "sv": "svenska",
+                    "en": "Swedish"
+                  },
+                  "lyhytNimi": {
+                    "fi": "ruotsi",
+                    "sv": "svenska",
+                    "en": "Swedish"
+                  },
+                  "koodistoUri": "kielivalikoima",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 8,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "5",
+                    "nimi": {
+                      "fi": "välttävä",
+                      "sv": "försvarlig",
+                      "en": "adequate"
+                    },
+                    "lyhytNimi": {
+                      "fi": "5"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "MA",
+                  "nimi": {
+                    "fi": "Matematiikka",
+                    "sv": "Matematik",
+                    "en": "Mathematics"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Matematiikka",
+                    "sv": "Matematik"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 4,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "5",
+                    "nimi": {
+                      "fi": "välttävä",
+                      "sv": "försvarlig",
+                      "en": "adequate"
+                    },
+                    "lyhytNimi": {
+                      "fi": "5"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "BI",
+                  "nimi": {
+                    "fi": "Biologia",
+                    "sv": "Biologi",
+                    "en": "Biology"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Biologia",
+                    "sv": "Biologi"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 4,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "5",
+                    "nimi": {
+                      "fi": "välttävä",
+                      "sv": "försvarlig",
+                      "en": "adequate"
+                    },
+                    "lyhytNimi": {
+                      "fi": "5"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "GE",
+                  "nimi": {
+                    "fi": "Maantieto",
+                    "sv": "Geografi",
+                    "en": "Geography"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Maantieto",
+                    "sv": "Geografi"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 4,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "5",
+                    "nimi": {
+                      "fi": "välttävä",
+                      "sv": "försvarlig",
+                      "en": "adequate"
+                    },
+                    "lyhytNimi": {
+                      "fi": "5"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "FY",
+                  "nimi": {
+                    "fi": "Fysiikka",
+                    "sv": "Fysik",
+                    "en": "Physics"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Fysiikka",
+                    "sv": "Fysik"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 4,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "5",
+                    "nimi": {
+                      "fi": "välttävä",
+                      "sv": "försvarlig",
+                      "en": "adequate"
+                    },
+                    "lyhytNimi": {
+                      "fi": "5"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "KE",
+                  "nimi": {
+                    "fi": "Kemia",
+                    "sv": "Kemi",
+                    "en": "Chemistry"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Kemia",
+                    "sv": "Kemi"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 4,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "5",
+                    "nimi": {
+                      "fi": "välttävä",
+                      "sv": "försvarlig",
+                      "en": "adequate"
+                    },
+                    "lyhytNimi": {
+                      "fi": "5"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "TE",
+                  "nimi": {
+                    "fi": "Terveystieto",
+                    "sv": "Hälsokunskap",
+                    "en": "Health education"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Terveystieto",
+                    "sv": "Hälsokunskap"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 4,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "5",
+                    "nimi": {
+                      "fi": "välttävä",
+                      "sv": "försvarlig",
+                      "en": "adequate"
+                    },
+                    "lyhytNimi": {
+                      "fi": "5"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "KT",
+                  "nimi": {
+                    "fi": "Uskonto/Elämänkatsomustieto",
+                    "sv": "Religion/Livsåskådningskunskap",
+                    "en": "Religion/ethics"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Uskonto",
+                    "sv": "Religion"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 4,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "5",
+                    "nimi": {
+                      "fi": "välttävä",
+                      "sv": "försvarlig",
+                      "en": "adequate"
+                    },
+                    "lyhytNimi": {
+                      "fi": "5"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "HI",
+                  "nimi": {
+                    "fi": "Historia",
+                    "sv": "Historia",
+                    "en": "History"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Historia",
+                    "sv": "Historia"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 4,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "5",
+                    "nimi": {
+                      "fi": "välttävä",
+                      "sv": "försvarlig",
+                      "en": "adequate"
+                    },
+                    "lyhytNimi": {
+                      "fi": "5"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "YH",
+                  "nimi": {
+                    "fi": "Yhteiskuntaoppi",
+                    "sv": "Samhällslära",
+                    "en": "Social studies"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Yhteiskuntaoppi",
+                    "sv": "Samhällslära"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 4,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "5",
+                    "nimi": {
+                      "fi": "välttävä",
+                      "sv": "försvarlig",
+                      "en": "adequate"
+                    },
+                    "lyhytNimi": {
+                      "fi": "5"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "MU",
+                  "nimi": {
+                    "fi": "Musiikki",
+                    "sv": "Musik",
+                    "en": "Music"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Musiikki",
+                    "sv": "Musik"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 4,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "5",
+                    "nimi": {
+                      "fi": "välttävä",
+                      "sv": "försvarlig",
+                      "en": "adequate"
+                    },
+                    "lyhytNimi": {
+                      "fi": "5"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "KU",
+                  "nimi": {
+                    "fi": "Kuvataide",
+                    "sv": "Bildkonst",
+                    "en": "Visual arts"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Kuvataide",
+                    "sv": "Bildkonst"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 2,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "5",
+                    "nimi": {
+                      "fi": "välttävä",
+                      "sv": "försvarlig",
+                      "en": "adequate"
+                    },
+                    "lyhytNimi": {
+                      "fi": "5"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "KS",
+                  "nimi": {
+                    "fi": "Käsityö",
+                    "sv": "Slöjd",
+                    "en": "Crafts"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Käsityö",
+                    "sv": "Slöjd"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 2,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "5",
+                    "nimi": {
+                      "fi": "välttävä",
+                      "sv": "försvarlig",
+                      "en": "adequate"
+                    },
+                    "lyhytNimi": {
+                      "fi": "5"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LI",
+                  "nimi": {
+                    "fi": "Liikunta",
+                    "sv": "Gymnastik",
+                    "en": "Physical education"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Liikunta",
+                    "sv": "Gymnastik"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 2,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "5",
+                    "nimi": {
+                      "fi": "välttävä",
+                      "sv": "försvarlig",
+                      "en": "adequate"
+                    },
+                    "lyhytNimi": {
+                      "fi": "5"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "KO",
+                  "nimi": {
+                    "fi": "Kotitalous",
+                    "sv": "Huslig ekonomi",
+                    "en": "Home economics"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Kotitalous",
+                    "sv": "Huslig ekonomi"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 2,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "5",
+                    "nimi": {
+                      "fi": "välttävä",
+                      "sv": "försvarlig",
+                      "en": "adequate"
+                    },
+                    "lyhytNimi": {
+                      "fi": "5"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "OP",
+                  "nimi": {
+                    "fi": "Opinto-ohjaus",
+                    "sv": "Elevhandledning",
+                    "en": "Guidance counselling"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Opinto-ohjaus"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 2,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "5",
+                    "nimi": {
+                      "fi": "välttävä",
+                      "sv": "försvarlig",
+                      "en": "adequate"
+                    },
+                    "lyhytNimi": {
+                      "fi": "5"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            }
+          ],
+          "tyyppi": {
+            "koodiarvo": "perusopetuksenvuosiluokka",
+            "nimi": {
+              "fi": "Perusopetuksen vuosiluokka",
+              "sv": "Årskurs i grundläggande utbildning",
+              "en": "Basic education class"
+            },
+            "koodistoUri": "suorituksentyyppi",
+            "koodistoVersio": 1
+          }
+        }
+      ],
+      "tyyppi": {
+        "koodiarvo": "perusopetus",
+        "nimi": {
+          "fi": "Perusopetus",
+          "sv": "Grundläggande utbildning",
+          "en": "Basic education"
+        },
+        "lyhytNimi": {
+          "fi": "Perusopetus"
+        },
+        "koodistoUri": "opiskeluoikeudentyyppi",
+        "koodistoVersio": 1
+      },
+      "alkamispäivä": "2023-08-10",
+      "päättymispäivä": "2024-05-14"
+    }
+  ]
+}

--- a/src/test/scala/fi/vm/sade/hakurekisteri/integration/koski/json/koskidata_perusopetus_valmis_jaanyt_9luokalle.json
+++ b/src/test/scala/fi/vm/sade/hakurekisteri/integration/koski/json/koskidata_perusopetus_valmis_jaanyt_9luokalle.json
@@ -1,0 +1,3049 @@
+{
+  "henkilö": {
+    "oid": "1.2.246.562.24.73723145512",
+    "hetu": "010177-9200",
+    "syntymäaika": "1977-01-01",
+    "etunimet": "Aada Testi",
+    "kutsumanimi": "Aada",
+    "sukunimi": "Nyman-Testi",
+    "äidinkieli": {
+      "koodiarvo": "FI",
+      "nimi": {
+        "fi": "suomi",
+        "sv": "finska",
+        "en": "Finnish"
+      },
+      "lyhytNimi": {
+        "fi": "suomi",
+        "sv": "finska",
+        "en": "Finnish"
+      },
+      "koodistoUri": "kieli",
+      "koodistoVersio": 1
+    },
+    "kansalaisuus": [
+      {
+        "koodiarvo": "246",
+        "nimi": {
+          "fi": "Suomi",
+          "sv": "Finland",
+          "en": "Finland"
+        },
+        "lyhytNimi": {
+          "fi": "FI",
+          "sv": "FI",
+          "en": "FI"
+        },
+        "koodistoUri": "maatjavaltiot2",
+        "koodistoVersio": 2
+      }
+    ],
+    "turvakielto": false
+  },
+  "opiskeluoikeudet": [
+    {
+      "oid": "1.2.246.562.15.64020606717",
+      "versionumero": 11,
+      "aikaleima": "2024-05-10T09:52:50.866857",
+      "oppilaitos": {
+        "oid": "1.2.246.562.10.767795477110",
+        "oppilaitosnumero": {
+          "koodiarvo": "07137",
+          "nimi": {
+            "fi": "Vehkalahden koulu",
+            "sv": "Vehkalahden koulu",
+            "en": "Vehkalahden koulu"
+          },
+          "lyhytNimi": {
+            "fi": "Vehkalahden koulu",
+            "sv": "Vehkalahden koulu",
+            "en": "Vehkalahden koulu"
+          },
+          "koodistoUri": "oppilaitosnumero",
+          "koodistoVersio": 1
+        },
+        "nimi": {
+          "fi": "Vehkalahden koulu",
+          "sv": "Vehkalahden koulu",
+          "en": "Vehkalahden koulu"
+        },
+        "kotipaikka": {
+          "koodiarvo": "075",
+          "nimi": {
+            "fi": "Hamina",
+            "sv": "Fredrikshamn"
+          },
+          "koodistoUri": "kunta",
+          "koodistoVersio": 2
+        }
+      },
+      "koulutustoimija": {
+        "oid": "1.2.246.562.10.31717716703",
+        "nimi": {
+          "fi": "Haminan kaupunki",
+          "sv": "Haminan kaupunki",
+          "en": "Haminan kaupunki"
+        },
+        "yTunnus": "0242496-6",
+        "kotipaikka": {
+          "koodiarvo": "075",
+          "nimi": {
+            "fi": "Hamina",
+            "sv": "Fredrikshamn"
+          },
+          "koodistoUri": "kunta",
+          "koodistoVersio": 2
+        }
+      },
+      "tila": {
+        "opiskeluoikeusjaksot": [
+          {
+            "alku": "2021-08-10",
+            "tila": {
+              "koodiarvo": "lasna",
+              "nimi": {
+                "fi": "Läsnä",
+                "sv": "Närvarande",
+                "en": "Present"
+              },
+              "koodistoUri": "koskiopiskeluoikeudentila",
+              "koodistoVersio": 1
+            }
+          },
+          {
+            "alku": "2024-05-10",
+            "tila": {
+              "koodiarvo": "valmistunut",
+              "nimi": {
+                "fi": "Valmistunut",
+                "sv": "Utexaminerad",
+                "en": "Graduated"
+              },
+              "koodistoUri": "koskiopiskeluoikeudentila",
+              "koodistoVersio": 1
+            }
+          }
+        ]
+      },
+      "suoritukset": [
+        {
+          "koulutusmoduuli": {
+            "perusteenDiaarinumero": "104/011/2014",
+            "tunniste": {
+              "koodiarvo": "201101",
+              "nimi": {
+                "fi": "Perusopetus",
+                "sv": "Grundläggande utbildning",
+                "en": "Basic education"
+              },
+              "koodistoUri": "koulutus",
+              "koodistoVersio": 12
+            },
+            "koulutustyyppi": {
+              "koodiarvo": "16",
+              "nimi": {
+                "fi": "Perusopetus",
+                "sv": "Grundläggande utbildning"
+              },
+              "lyhytNimi": {
+                "fi": "Perusopetus",
+                "sv": "Grundläggande utbildning"
+              },
+              "koodistoUri": "koulutustyyppi"
+            }
+          },
+          "toimipiste": {
+            "oid": "1.2.246.562.10.767795477110",
+            "oppilaitosnumero": {
+              "koodiarvo": "07137",
+              "nimi": {
+                "fi": "Vehkalahden koulu",
+                "sv": "Vehkalahden koulu",
+                "en": "Vehkalahden koulu"
+              },
+              "lyhytNimi": {
+                "fi": "Vehkalahden koulu",
+                "sv": "Vehkalahden koulu",
+                "en": "Vehkalahden koulu"
+              },
+              "koodistoUri": "oppilaitosnumero",
+              "koodistoVersio": 1
+            },
+            "nimi": {
+              "fi": "Vehkalahden koulu",
+              "sv": "Vehkalahden koulu",
+              "en": "Vehkalahden koulu"
+            },
+            "kotipaikka": {
+              "koodiarvo": "075",
+              "nimi": {
+                "fi": "Hamina",
+                "sv": "Fredrikshamn"
+              },
+              "koodistoUri": "kunta",
+              "koodistoVersio": 2
+            }
+          },
+          "vahvistus": {
+            "päivä": "2024-05-10",
+            "paikkakunta": {
+              "koodiarvo": "075",
+              "nimi": {
+                "fi": "Hamina",
+                "sv": "Fredrikshamn"
+              },
+              "koodistoUri": "kunta",
+              "koodistoVersio": 2
+            },
+            "myöntäjäOrganisaatio": {
+              "oid": "1.2.246.562.10.767795477110",
+              "oppilaitosnumero": {
+                "koodiarvo": "07137",
+                "nimi": {
+                  "fi": "Vehkalahden koulu",
+                  "sv": "Vehkalahden koulu",
+                  "en": "Vehkalahden koulu"
+                },
+                "lyhytNimi": {
+                  "fi": "Vehkalahden koulu",
+                  "sv": "Vehkalahden koulu",
+                  "en": "Vehkalahden koulu"
+                },
+                "koodistoUri": "oppilaitosnumero",
+                "koodistoVersio": 1
+              },
+              "nimi": {
+                "fi": "Vehkalahden koulu",
+                "sv": "Vehkalahden koulu",
+                "en": "Vehkalahden koulu"
+              },
+              "kotipaikka": {
+                "koodiarvo": "075",
+                "nimi": {
+                  "fi": "Hamina",
+                  "sv": "Fredrikshamn"
+                },
+                "koodistoUri": "kunta",
+                "koodistoVersio": 2
+              }
+            },
+            "myöntäjäHenkilöt": [
+              {
+                "nimi": "Hesse Trademark",
+                "titteli": {
+                  "fi": "varareksi"
+                },
+                "organisaatio": {
+                  "oid": "1.2.246.562.10.767795477110",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "07137",
+                    "nimi": {
+                      "fi": "Vehkalahden koulu",
+                      "sv": "Vehkalahden koulu",
+                      "en": "Vehkalahden koulu"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Vehkalahden koulu",
+                      "sv": "Vehkalahden koulu",
+                      "en": "Vehkalahden koulu"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Vehkalahden koulu",
+                    "sv": "Vehkalahden koulu",
+                    "en": "Vehkalahden koulu"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "075",
+                    "nimi": {
+                      "fi": "Hamina",
+                      "sv": "Fredrikshamn"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              }
+            ]
+          },
+          "suoritustapa": {
+            "koodiarvo": "koulutus",
+            "nimi": {
+              "fi": "Koulutus",
+              "sv": "Utbildning",
+              "en": "Education"
+            },
+            "koodistoUri": "perusopetuksensuoritustapa",
+            "koodistoVersio": 1
+          },
+          "suorituskieli": {
+            "koodiarvo": "FI",
+            "nimi": {
+              "fi": "suomi",
+              "sv": "finska",
+              "en": "Finnish"
+            },
+            "lyhytNimi": {
+              "fi": "suomi",
+              "sv": "finska",
+              "en": "Finnish"
+            },
+            "koodistoUri": "kieli",
+            "koodistoVersio": 1
+          },
+          "osasuoritukset": [
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "AI",
+                  "nimi": {
+                    "fi": "Äidinkieli ja kirjallisuus",
+                    "sv": "Modersmålet och litteratur",
+                    "en": "Mother tongue and literature"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Äidinkieli ja kirjallisuus",
+                    "sv": "Modersmålet och litteratur"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "kieli": {
+                  "koodiarvo": "AI1",
+                  "nimi": {
+                    "fi": "Suomen kieli ja kirjallisuus",
+                    "sv": "Finska och litteratur",
+                    "en": "Finnish language and literature"
+                  },
+                  "koodistoUri": "oppiaineaidinkielijakirjallisuus",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 33,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": true,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "8",
+                    "nimi": {
+                      "fi": "hyvä",
+                      "sv": "god",
+                      "en": "good"
+                    },
+                    "lyhytNimi": {
+                      "fi": "8"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              },
+              "suoritustapa": {
+                "koodiarvo": "erityinentutkinto",
+                "nimi": {
+                  "fi": "Erityinen tutkinto",
+                  "sv": "Särskild examen",
+                  "en": "Separate basic education examination"
+                },
+                "koodistoUri": "perusopetuksensuoritustapa",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "A1",
+                  "nimi": {
+                    "fi": "A1-kieli",
+                    "sv": "A1-språk",
+                    "en": "A1-language"
+                  },
+                  "lyhytNimi": {
+                    "fi": "A1-kieli",
+                    "sv": "A1-språk"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "kieli": {
+                  "koodiarvo": "EN",
+                  "nimi": {
+                    "fi": "englanti",
+                    "sv": "engelska",
+                    "en": "English"
+                  },
+                  "lyhytNimi": {
+                    "fi": "englanti",
+                    "sv": "engelska",
+                    "en": "English"
+                  },
+                  "koodistoUri": "kielivalikoima",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 23,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "8",
+                    "nimi": {
+                      "fi": "hyvä",
+                      "sv": "god",
+                      "en": "good"
+                    },
+                    "lyhytNimi": {
+                      "fi": "8"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "B1",
+                  "nimi": {
+                    "fi": "B1-kieli",
+                    "sv": "B1-språk",
+                    "en": "B1-language"
+                  },
+                  "lyhytNimi": {
+                    "fi": "B1-kieli",
+                    "sv": "B1-språk"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "kieli": {
+                  "koodiarvo": "SV",
+                  "nimi": {
+                    "fi": "ruotsi",
+                    "sv": "svenska",
+                    "en": "Swedish"
+                  },
+                  "lyhytNimi": {
+                    "fi": "ruotsi",
+                    "sv": "svenska",
+                    "en": "Swedish"
+                  },
+                  "koodistoUri": "kielivalikoima",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 22,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "7",
+                    "nimi": {
+                      "fi": "tyydyttävä",
+                      "sv": "nöjaktig",
+                      "en": "satisfactory"
+                    },
+                    "lyhytNimi": {
+                      "fi": "7"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "MA",
+                  "nimi": {
+                    "fi": "Matematiikka",
+                    "sv": "Matematik",
+                    "en": "Mathematics"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Matematiikka",
+                    "sv": "Matematik"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 32,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": true,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "10",
+                    "nimi": {
+                      "fi": "erinomainen",
+                      "sv": "utmärkt",
+                      "en": "excellent"
+                    },
+                    "lyhytNimi": {
+                      "fi": "10"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "suorituskieli": {
+                "koodiarvo": "FI",
+                "nimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "lyhytNimi": {
+                  "fi": "suomi",
+                  "sv": "finska",
+                  "en": "Finnish"
+                },
+                "koodistoUri": "kieli",
+                "koodistoVersio": 1
+              },
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              },
+              "suoritustapa": {
+                "koodiarvo": "erityinentutkinto",
+                "nimi": {
+                  "fi": "Erityinen tutkinto",
+                  "sv": "Särskild examen",
+                  "en": "Separate basic education examination"
+                },
+                "koodistoUri": "perusopetuksensuoritustapa",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "BI",
+                  "nimi": {
+                    "fi": "Biologia",
+                    "sv": "Biologi",
+                    "en": "Biology"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Biologia",
+                    "sv": "Biologi"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 7,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "8",
+                    "nimi": {
+                      "fi": "hyvä",
+                      "sv": "god",
+                      "en": "good"
+                    },
+                    "lyhytNimi": {
+                      "fi": "8"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "GE",
+                  "nimi": {
+                    "fi": "Maantieto",
+                    "sv": "Geografi",
+                    "en": "Geography"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Maantieto",
+                    "sv": "Geografi"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 5,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "7",
+                    "nimi": {
+                      "fi": "tyydyttävä",
+                      "sv": "nöjaktig",
+                      "en": "satisfactory"
+                    },
+                    "lyhytNimi": {
+                      "fi": "7"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "FY",
+                  "nimi": {
+                    "fi": "Fysiikka",
+                    "sv": "Fysik",
+                    "en": "Physics"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Fysiikka",
+                    "sv": "Fysik"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 8,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "6",
+                    "nimi": {
+                      "fi": "kohtalainen",
+                      "sv": "hjälplig",
+                      "en": "moderate"
+                    },
+                    "lyhytNimi": {
+                      "fi": "6"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "KE",
+                  "nimi": {
+                    "fi": "Kemia",
+                    "sv": "Kemi",
+                    "en": "Chemistry"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Kemia",
+                    "sv": "Kemi"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 8,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "8",
+                    "nimi": {
+                      "fi": "hyvä",
+                      "sv": "god",
+                      "en": "good"
+                    },
+                    "lyhytNimi": {
+                      "fi": "8"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "TE",
+                  "nimi": {
+                    "fi": "Terveystieto",
+                    "sv": "Hälsokunskap",
+                    "en": "Health education"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Terveystieto",
+                    "sv": "Hälsokunskap"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 3,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "7",
+                    "nimi": {
+                      "fi": "tyydyttävä",
+                      "sv": "nöjaktig",
+                      "en": "satisfactory"
+                    },
+                    "lyhytNimi": {
+                      "fi": "7"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "KT",
+                  "nimi": {
+                    "fi": "Uskonto/Elämänkatsomustieto",
+                    "sv": "Religion/Livsåskådningskunskap",
+                    "en": "Religion/ethics"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Uskonto",
+                    "sv": "Religion"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 6,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "6",
+                    "nimi": {
+                      "fi": "kohtalainen",
+                      "sv": "hjälplig",
+                      "en": "moderate"
+                    },
+                    "lyhytNimi": {
+                      "fi": "6"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "HI",
+                  "nimi": {
+                    "fi": "Historia",
+                    "sv": "Historia",
+                    "en": "History"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Historia",
+                    "sv": "Historia"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 9,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "8",
+                    "nimi": {
+                      "fi": "hyvä",
+                      "sv": "god",
+                      "en": "good"
+                    },
+                    "lyhytNimi": {
+                      "fi": "8"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "YH",
+                  "nimi": {
+                    "fi": "Yhteiskuntaoppi",
+                    "sv": "Samhällslära",
+                    "en": "Social studies"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Yhteiskuntaoppi",
+                    "sv": "Samhällslära"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 6,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "9",
+                    "nimi": {
+                      "fi": "kiitettävä",
+                      "sv": "berömlig",
+                      "en": "excellent"
+                    },
+                    "lyhytNimi": {
+                      "fi": "9"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "MU",
+                  "nimi": {
+                    "fi": "Musiikki",
+                    "sv": "Musik",
+                    "en": "Music"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Musiikki",
+                    "sv": "Musik"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 7,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "10",
+                    "nimi": {
+                      "fi": "erinomainen",
+                      "sv": "utmärkt",
+                      "en": "excellent"
+                    },
+                    "lyhytNimi": {
+                      "fi": "10"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "KU",
+                  "nimi": {
+                    "fi": "Kuvataide",
+                    "sv": "Bildkonst",
+                    "en": "Visual arts"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Kuvataide",
+                    "sv": "Bildkonst"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 5,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "7",
+                    "nimi": {
+                      "fi": "tyydyttävä",
+                      "sv": "nöjaktig",
+                      "en": "satisfactory"
+                    },
+                    "lyhytNimi": {
+                      "fi": "7"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "KS",
+                  "nimi": {
+                    "fi": "Käsityö",
+                    "sv": "Slöjd",
+                    "en": "Crafts"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Käsityö",
+                    "sv": "Slöjd"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 5,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "6",
+                    "nimi": {
+                      "fi": "kohtalainen",
+                      "sv": "hjälplig",
+                      "en": "moderate"
+                    },
+                    "lyhytNimi": {
+                      "fi": "6"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LI",
+                  "nimi": {
+                    "fi": "Liikunta",
+                    "sv": "Gymnastik",
+                    "en": "Physical education"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Liikunta",
+                    "sv": "Gymnastik"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 11,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "8",
+                    "nimi": {
+                      "fi": "hyvä",
+                      "sv": "god",
+                      "en": "good"
+                    },
+                    "lyhytNimi": {
+                      "fi": "8"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "KO",
+                  "nimi": {
+                    "fi": "Kotitalous",
+                    "sv": "Huslig ekonomi",
+                    "en": "Home economics"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Kotitalous",
+                    "sv": "Huslig ekonomi"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 5,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "7",
+                    "nimi": {
+                      "fi": "tyydyttävä",
+                      "sv": "nöjaktig",
+                      "en": "satisfactory"
+                    },
+                    "lyhytNimi": {
+                      "fi": "7"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "OP",
+                  "nimi": {
+                    "fi": "Opinto-ohjaus",
+                    "sv": "Elevhandledning",
+                    "en": "Guidance counselling"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Opinto-ohjaus"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 2,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "S",
+                    "nimi": {
+                      "fi": "hyväksytty",
+                      "sv": "godkänd",
+                      "en": "pass"
+                    },
+                    "lyhytNimi": {
+                      "fi": "S"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            }
+          ],
+          "tyyppi": {
+            "koodiarvo": "perusopetuksenoppimaara",
+            "nimi": {
+              "fi": "Perusopetuksen oppimäärä",
+              "sv": "Grundläggande utbildningens lärokurs",
+              "en": "Basic education syllabus"
+            },
+            "koodistoUri": "suorituksentyyppi",
+            "koodistoVersio": 1
+          },
+          "koulusivistyskieli": [
+            {
+              "koodiarvo": "FI",
+              "nimi": {
+                "fi": "suomi"
+              },
+              "koodistoUri": "kieli"
+            }
+          ]
+        },
+        {
+          "koulutusmoduuli": {
+            "tunniste": {
+              "koodiarvo": "9",
+              "nimi": {
+                "fi": "9. vuosiluokka",
+                "sv": "Årskurs 9",
+                "en": "9th grade"
+              },
+              "koodistoUri": "perusopetuksenluokkaaste",
+              "koodistoVersio": 1
+            },
+            "perusteenDiaarinumero": "104/011/2014",
+            "koulutustyyppi": {
+              "koodiarvo": "16",
+              "nimi": {
+                "fi": "Perusopetus",
+                "sv": "Grundläggande utbildning"
+              },
+              "lyhytNimi": {
+                "fi": "Perusopetus",
+                "sv": "Grundläggande utbildning"
+              },
+              "koodistoUri": "koulutustyyppi"
+            }
+          },
+          "luokka": "9B",
+          "toimipiste": {
+            "oid": "1.2.246.562.10.767795477110",
+            "oppilaitosnumero": {
+              "koodiarvo": "07137",
+              "nimi": {
+                "fi": "Vehkalahden koulu",
+                "sv": "Vehkalahden koulu",
+                "en": "Vehkalahden koulu"
+              },
+              "lyhytNimi": {
+                "fi": "Vehkalahden koulu",
+                "sv": "Vehkalahden koulu",
+                "en": "Vehkalahden koulu"
+              },
+              "koodistoUri": "oppilaitosnumero",
+              "koodistoVersio": 1
+            },
+            "nimi": {
+              "fi": "Vehkalahden koulu",
+              "sv": "Vehkalahden koulu",
+              "en": "Vehkalahden koulu"
+            },
+            "kotipaikka": {
+              "koodiarvo": "075",
+              "nimi": {
+                "fi": "Hamina",
+                "sv": "Fredrikshamn"
+              },
+              "koodistoUri": "kunta",
+              "koodistoVersio": 2
+            }
+          },
+          "alkamispäivä": "2021-08-10",
+          "vahvistus": {
+            "päivä": "2022-05-30",
+            "paikkakunta": {
+              "koodiarvo": "075",
+              "nimi": {
+                "fi": "Hamina",
+                "sv": "Fredrikshamn"
+              },
+              "koodistoUri": "kunta",
+              "koodistoVersio": 2
+            },
+            "myöntäjäOrganisaatio": {
+              "oid": "1.2.246.562.10.767795477110",
+              "oppilaitosnumero": {
+                "koodiarvo": "07137",
+                "nimi": {
+                  "fi": "Vehkalahden koulu",
+                  "sv": "Vehkalahden koulu",
+                  "en": "Vehkalahden koulu"
+                },
+                "lyhytNimi": {
+                  "fi": "Vehkalahden koulu",
+                  "sv": "Vehkalahden koulu",
+                  "en": "Vehkalahden koulu"
+                },
+                "koodistoUri": "oppilaitosnumero",
+                "koodistoVersio": 1
+              },
+              "nimi": {
+                "fi": "Vehkalahden koulu",
+                "sv": "Vehkalahden koulu",
+                "en": "Vehkalahden koulu"
+              },
+              "kotipaikka": {
+                "koodiarvo": "075",
+                "nimi": {
+                  "fi": "Hamina",
+                  "sv": "Fredrikshamn"
+                },
+                "koodistoUri": "kunta",
+                "koodistoVersio": 2
+              }
+            },
+            "myöntäjäHenkilöt": [
+              {
+                "nimi": "Hesse Trademark",
+                "titteli": {
+                  "fi": "varareksi"
+                },
+                "organisaatio": {
+                  "oid": "1.2.246.562.10.767795477110",
+                  "oppilaitosnumero": {
+                    "koodiarvo": "07137",
+                    "nimi": {
+                      "fi": "Vehkalahden koulu",
+                      "sv": "Vehkalahden koulu",
+                      "en": "Vehkalahden koulu"
+                    },
+                    "lyhytNimi": {
+                      "fi": "Vehkalahden koulu",
+                      "sv": "Vehkalahden koulu",
+                      "en": "Vehkalahden koulu"
+                    },
+                    "koodistoUri": "oppilaitosnumero",
+                    "koodistoVersio": 1
+                  },
+                  "nimi": {
+                    "fi": "Vehkalahden koulu",
+                    "sv": "Vehkalahden koulu",
+                    "en": "Vehkalahden koulu"
+                  },
+                  "kotipaikka": {
+                    "koodiarvo": "075",
+                    "nimi": {
+                      "fi": "Hamina",
+                      "sv": "Fredrikshamn"
+                    },
+                    "koodistoUri": "kunta",
+                    "koodistoVersio": 2
+                  }
+                }
+              }
+            ]
+          },
+          "suorituskieli": {
+            "koodiarvo": "FI",
+            "nimi": {
+              "fi": "suomi",
+              "sv": "finska",
+              "en": "Finnish"
+            },
+            "lyhytNimi": {
+              "fi": "suomi",
+              "sv": "finska",
+              "en": "Finnish"
+            },
+            "koodistoUri": "kieli",
+            "koodistoVersio": 1
+          },
+          "jääLuokalle": true,
+          "osasuoritukset": [
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "AI",
+                  "nimi": {
+                    "fi": "Äidinkieli ja kirjallisuus",
+                    "sv": "Modersmålet och litteratur",
+                    "en": "Mother tongue and literature"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Äidinkieli ja kirjallisuus",
+                    "sv": "Modersmålet och litteratur"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "kieli": {
+                  "koodiarvo": "AI1",
+                  "nimi": {
+                    "fi": "Suomen kieli ja kirjallisuus",
+                    "sv": "Finska och litteratur",
+                    "en": "Finnish language and literature"
+                  },
+                  "koodistoUri": "oppiaineaidinkielijakirjallisuus",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 2,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "4",
+                    "nimi": {
+                      "fi": "hylätty",
+                      "sv": "underkänd",
+                      "en": "fail"
+                    },
+                    "lyhytNimi": {
+                      "fi": "4"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": false
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "A1",
+                  "nimi": {
+                    "fi": "A1-kieli",
+                    "sv": "A1-språk",
+                    "en": "A1-language"
+                  },
+                  "lyhytNimi": {
+                    "fi": "A1-kieli",
+                    "sv": "A1-språk"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "kieli": {
+                  "koodiarvo": "EN",
+                  "nimi": {
+                    "fi": "englanti",
+                    "sv": "engelska",
+                    "en": "English"
+                  },
+                  "lyhytNimi": {
+                    "fi": "englanti",
+                    "sv": "engelska",
+                    "en": "English"
+                  },
+                  "koodistoUri": "kielivalikoima",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 2,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "4",
+                    "nimi": {
+                      "fi": "hylätty",
+                      "sv": "underkänd",
+                      "en": "fail"
+                    },
+                    "lyhytNimi": {
+                      "fi": "4"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": false
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "B1",
+                  "nimi": {
+                    "fi": "B1-kieli",
+                    "sv": "B1-språk",
+                    "en": "B1-language"
+                  },
+                  "lyhytNimi": {
+                    "fi": "B1-kieli",
+                    "sv": "B1-språk"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "kieli": {
+                  "koodiarvo": "SV",
+                  "nimi": {
+                    "fi": "ruotsi",
+                    "sv": "svenska",
+                    "en": "Swedish"
+                  },
+                  "lyhytNimi": {
+                    "fi": "ruotsi",
+                    "sv": "svenska",
+                    "en": "Swedish"
+                  },
+                  "koodistoUri": "kielivalikoima",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 2,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "4",
+                    "nimi": {
+                      "fi": "hylätty",
+                      "sv": "underkänd",
+                      "en": "fail"
+                    },
+                    "lyhytNimi": {
+                      "fi": "4"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": false
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "MA",
+                  "nimi": {
+                    "fi": "Matematiikka",
+                    "sv": "Matematik",
+                    "en": "Mathematics"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Matematiikka",
+                    "sv": "Matematik"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 2,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "5",
+                    "nimi": {
+                      "fi": "välttävä",
+                      "sv": "försvarlig",
+                      "en": "adequate"
+                    },
+                    "lyhytNimi": {
+                      "fi": "5"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "BI",
+                  "nimi": {
+                    "fi": "Biologia",
+                    "sv": "Biologi",
+                    "en": "Biology"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Biologia",
+                    "sv": "Biologi"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 2,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "5",
+                    "nimi": {
+                      "fi": "välttävä",
+                      "sv": "försvarlig",
+                      "en": "adequate"
+                    },
+                    "lyhytNimi": {
+                      "fi": "5"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "GE",
+                  "nimi": {
+                    "fi": "Maantieto",
+                    "sv": "Geografi",
+                    "en": "Geography"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Maantieto",
+                    "sv": "Geografi"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 2,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "5",
+                    "nimi": {
+                      "fi": "välttävä",
+                      "sv": "försvarlig",
+                      "en": "adequate"
+                    },
+                    "lyhytNimi": {
+                      "fi": "5"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "FY",
+                  "nimi": {
+                    "fi": "Fysiikka",
+                    "sv": "Fysik",
+                    "en": "Physics"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Fysiikka",
+                    "sv": "Fysik"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 2,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "5",
+                    "nimi": {
+                      "fi": "välttävä",
+                      "sv": "försvarlig",
+                      "en": "adequate"
+                    },
+                    "lyhytNimi": {
+                      "fi": "5"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "KE",
+                  "nimi": {
+                    "fi": "Kemia",
+                    "sv": "Kemi",
+                    "en": "Chemistry"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Kemia",
+                    "sv": "Kemi"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 2,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "5",
+                    "nimi": {
+                      "fi": "välttävä",
+                      "sv": "försvarlig",
+                      "en": "adequate"
+                    },
+                    "lyhytNimi": {
+                      "fi": "5"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "TE",
+                  "nimi": {
+                    "fi": "Terveystieto",
+                    "sv": "Hälsokunskap",
+                    "en": "Health education"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Terveystieto",
+                    "sv": "Hälsokunskap"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 2,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "6",
+                    "nimi": {
+                      "fi": "kohtalainen",
+                      "sv": "hjälplig",
+                      "en": "moderate"
+                    },
+                    "lyhytNimi": {
+                      "fi": "6"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "KT",
+                  "nimi": {
+                    "fi": "Uskonto/Elämänkatsomustieto",
+                    "sv": "Religion/Livsåskådningskunskap",
+                    "en": "Religion/ethics"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Uskonto",
+                    "sv": "Religion"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 2,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "5",
+                    "nimi": {
+                      "fi": "välttävä",
+                      "sv": "försvarlig",
+                      "en": "adequate"
+                    },
+                    "lyhytNimi": {
+                      "fi": "5"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "HI",
+                  "nimi": {
+                    "fi": "Historia",
+                    "sv": "Historia",
+                    "en": "History"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Historia",
+                    "sv": "Historia"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 2,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "5",
+                    "nimi": {
+                      "fi": "välttävä",
+                      "sv": "försvarlig",
+                      "en": "adequate"
+                    },
+                    "lyhytNimi": {
+                      "fi": "5"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "YH",
+                  "nimi": {
+                    "fi": "Yhteiskuntaoppi",
+                    "sv": "Samhällslära",
+                    "en": "Social studies"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Yhteiskuntaoppi",
+                    "sv": "Samhällslära"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 2,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "5",
+                    "nimi": {
+                      "fi": "välttävä",
+                      "sv": "försvarlig",
+                      "en": "adequate"
+                    },
+                    "lyhytNimi": {
+                      "fi": "5"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "MU",
+                  "nimi": {
+                    "fi": "Musiikki",
+                    "sv": "Musik",
+                    "en": "Music"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Musiikki",
+                    "sv": "Musik"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 2,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "5",
+                    "nimi": {
+                      "fi": "välttävä",
+                      "sv": "försvarlig",
+                      "en": "adequate"
+                    },
+                    "lyhytNimi": {
+                      "fi": "5"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "KU",
+                  "nimi": {
+                    "fi": "Kuvataide",
+                    "sv": "Bildkonst",
+                    "en": "Visual arts"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Kuvataide",
+                    "sv": "Bildkonst"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 2,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "5",
+                    "nimi": {
+                      "fi": "välttävä",
+                      "sv": "försvarlig",
+                      "en": "adequate"
+                    },
+                    "lyhytNimi": {
+                      "fi": "5"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "KS",
+                  "nimi": {
+                    "fi": "Käsityö",
+                    "sv": "Slöjd",
+                    "en": "Crafts"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Käsityö",
+                    "sv": "Slöjd"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 2,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "4",
+                    "nimi": {
+                      "fi": "hylätty",
+                      "sv": "underkänd",
+                      "en": "fail"
+                    },
+                    "lyhytNimi": {
+                      "fi": "4"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": false
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "LI",
+                  "nimi": {
+                    "fi": "Liikunta",
+                    "sv": "Gymnastik",
+                    "en": "Physical education"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Liikunta",
+                    "sv": "Gymnastik"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 2,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "5",
+                    "nimi": {
+                      "fi": "välttävä",
+                      "sv": "försvarlig",
+                      "en": "adequate"
+                    },
+                    "lyhytNimi": {
+                      "fi": "5"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "KO",
+                  "nimi": {
+                    "fi": "Kotitalous",
+                    "sv": "Huslig ekonomi",
+                    "en": "Home economics"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Kotitalous",
+                    "sv": "Huslig ekonomi"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 2,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "7",
+                    "nimi": {
+                      "fi": "tyydyttävä",
+                      "sv": "nöjaktig",
+                      "en": "satisfactory"
+                    },
+                    "lyhytNimi": {
+                      "fi": "7"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            },
+            {
+              "koulutusmoduuli": {
+                "tunniste": {
+                  "koodiarvo": "OP",
+                  "nimi": {
+                    "fi": "Opinto-ohjaus",
+                    "sv": "Elevhandledning",
+                    "en": "Guidance counselling"
+                  },
+                  "lyhytNimi": {
+                    "fi": "Opinto-ohjaus"
+                  },
+                  "koodistoUri": "koskioppiaineetyleissivistava",
+                  "koodistoVersio": 1
+                },
+                "pakollinen": true,
+                "laajuus": {
+                  "arvo": 2,
+                  "yksikkö": {
+                    "koodiarvo": "3",
+                    "nimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "lyhytNimi": {
+                      "fi": "vuosiviikkotuntia",
+                      "sv": "årsveckotimmar",
+                      "en": "weekly lessons per year"
+                    },
+                    "koodistoUri": "opintojenlaajuusyksikko",
+                    "koodistoVersio": 1
+                  }
+                }
+              },
+              "yksilöllistettyOppimäärä": false,
+              "painotettuOpetus": false,
+              "arviointi": [
+                {
+                  "arvosana": {
+                    "koodiarvo": "5",
+                    "nimi": {
+                      "fi": "välttävä",
+                      "sv": "försvarlig",
+                      "en": "adequate"
+                    },
+                    "lyhytNimi": {
+                      "fi": "5"
+                    },
+                    "koodistoUri": "arviointiasteikkoyleissivistava",
+                    "koodistoVersio": 1
+                  },
+                  "hyväksytty": true
+                }
+              ],
+              "tyyppi": {
+                "koodiarvo": "perusopetuksenoppiaine",
+                "nimi": {
+                  "fi": "Perusopetuksen oppiaine",
+                  "sv": "Läroämne i grundläggande utbildning",
+                  "en": "Basic education subject"
+                },
+                "koodistoUri": "suorituksentyyppi",
+                "koodistoVersio": 1
+              }
+            }
+          ],
+          "tyyppi": {
+            "koodiarvo": "perusopetuksenvuosiluokka",
+            "nimi": {
+              "fi": "Perusopetuksen vuosiluokka",
+              "sv": "Årskurs i grundläggande utbildning",
+              "en": "Basic education class"
+            },
+            "koodistoUri": "suorituksentyyppi",
+            "koodistoVersio": 1
+          }
+        }
+      ],
+      "tyyppi": {
+        "koodiarvo": "perusopetus",
+        "nimi": {
+          "fi": "Perusopetus",
+          "sv": "Grundläggande utbildning",
+          "en": "Basic education"
+        },
+        "lyhytNimi": {
+          "fi": "Perusopetus"
+        },
+        "koodistoUri": "opiskeluoikeudentyyppi",
+        "koodistoVersio": 1
+      },
+      "alkamispäivä": "2021-08-10",
+      "päättymispäivä": "2024-05-10"
+    }
+  ]
+}


### PR DESCRIPTION
OY-4825 ei huomioida koskidatan jääluokalle-tietoa 9-luokalla jos on valmis perusopetuksen oppimäärä.
Poistettu myös hieman kuollutta koodia.